### PR TITLE
Update unifi.subdomain.conf

### DIFF
--- a/unifi.subdomain.conf.sample
+++ b/unifi.subdomain.conf.sample
@@ -40,9 +40,7 @@ server {
         resolver 127.0.0.11 valid=30s;
         set $upstream_unifi unifi;
         proxy_pass https://$upstream_unifi:8443;
-        proxy_redirect off;
         proxy_buffering off;
-        proxy_set_header Host $host;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
         proxy_ssl_verify off;


### PR DESCRIPTION
Proposed changes remedy a WebSocket Connection Error present in the Web UX when proxying to a 'unstable' 5.9.x letsencrypt/unifi container. Should be fine for stable branch installs as well, of course.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

