### PR TITLE
Add HomeAssistant subdomain sample

### DIFF
--- a/homeassistant.subdomain.conf.sample
+++ b/homeassistant.subdomain.conf.sample
@@ -1,0 +1,41 @@
+# make sure that your dns has a cname set for homeassistant and that your homeassistant container is not using a base url
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name homeassistant.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    # enable for ldap auth, fill in ldap details in ldap.conf
+    #include /config/nginx/ldap.conf;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable the next two lines for ldap auth
+        #auth_request /auth;
+        #error_page 401 =200 /login;
+
+        include /config/nginx/proxy.conf;
+        resolver 127.0.0.11 valid=30s;
+        set $upstream_homeassistant homeassistant;
+        proxy_pass http://$upstream_homeassistant:8123;
+    }
+
+    location /api/websocket {
+        resolver 127.0.0.11 valid=30s;
+        set $upstream_homeassistant homeassistant;
+        proxy_pass http://$upstream_homeassistant:8123;
+        proxy_set_header Host $host;
+
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+}


### PR DESCRIPTION
Subdomain works fine for this. API location doesn't like proxy.conf so it's not included there. Subfolder config wasn't happy so it's not included.