### PR TITLE
Add actual ombi api

### DIFF
--- a/ombi.subdomain.conf.sample
+++ b/ombi.subdomain.conf.sample
@@ -28,6 +28,15 @@ server {
         proxy_pass http://$upstream_ombi:3579;
     }
 
+    # This allows access to the actual api
+    location ~ (/ombi)?/api {
+        include /config/nginx/proxy.conf;
+        resolver 127.0.0.11 valid=30s;
+        set $upstream_ombi ombi;
+        proxy_pass http://$upstream_ombi:3579;
+   }
+
+    # This allows access to the documentation for the api
     location ~ (/ombi)?/swagger {
         include /config/nginx/proxy.conf;
         resolver 127.0.0.11 valid=30s;

--- a/ombi.subfolder.conf.sample
+++ b/ombi.subfolder.conf.sample
@@ -19,6 +19,18 @@ location ^~ /ombi/ {
     proxy_pass http://$upstream_ombi:3579;
 }
 
+# This allows access to the actual api
+location ^~ /ombi/api {
+    include /config/nginx/proxy.conf;
+    resolver 127.0.0.11 valid=30s;
+    set $upstream_ombi ombi;
+    proxy_pass http://$upstream_ombi:3579;
+}
+if ($http_referer ~* /ombi) {
+    rewrite ^/api/(.*) /ombi/api/$1? redirect;
+}
+
+# This allows access to the documentation for the api
 location ^~ /ombi/swagger {
     include /config/nginx/proxy.conf;
     resolver 127.0.0.11 valid=30s;


### PR DESCRIPTION
After speaking with the Ombi support team I've found that the `/swagger` url is for their api's documentation and `/api` is actually the real api. I misunderstood this when I made the original PR to add `/swagger`.