### PR TITLE
Add trailing slash to Monitorr subfolder config

### DIFF
--- a/monitorr.subfolder.conf.sample
+++ b/monitorr.subfolder.conf.sample
@@ -1,6 +1,9 @@
 # monitorr does not require a base url setting
 
-location ^~ /monitorr {
+location /monitorr {
+    return 301 $scheme://$host/monitorr/;
+}
+location ^~ /monitorr/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;


### PR DESCRIPTION
Resolves issues reported by jbrown705#1217 on Discord.

I have confirmed the lack of trailing slash results in a 404 and adding the trailing slash resolves the issue.