### PR TITLE
Add Heimdall root subfolder sample

### DIFF
--- a/heimdall.subfolder.conf.sample
+++ b/heimdall.subfolder.conf.sample
@@ -1,0 +1,16 @@
+# In order to use this location block you need to edit the default file one folder up and comment out the / location
+
+location / {
+    # enable the next two lines for http auth
+    #auth_basic "Restricted";
+    #auth_basic_user_file /config/nginx/.htpasswd;
+
+    # enable the next two lines for ldap auth, also customize and enable ldap.conf in the default conf
+    #auth_request /auth;
+    #error_page 401 =200 /login;
+
+    include /config/nginx/proxy.conf;
+    resolver 127.0.0.11 valid=30s;
+    set $upstream_heimdall heimdall;
+    proxy_pass https://$upstream_heimdall:443;
+}


### PR DESCRIPTION
A user asked me how to put heimdall on the root of their domain rather than subdomain and I figured since this was missing it could be added. The location line in this config is setup the same as https://github.com/linuxserver/reverse-proxy-confs/blob/master/organizr.subfolder.conf.sample#L3 
