### PR TITLE
Add proxy samples for qBittorrent

### DIFF
--- a/qbittorrent.subdomain.conf.sample
+++ b/qbittorrent.subdomain.conf.sample
@@ -1,0 +1,32 @@
+# make sure that your dns has a cname set for qbittorrent and that your qbittorrent container is not using a base url
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name qbittorrent.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    # enable for ldap auth, fill in ldap details in ldap.conf
+    #include /config/nginx/ldap.conf;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable the next two lines for ldap auth
+        #auth_request /auth;
+        #error_page 401 =200 /login;
+
+        include /config/nginx/proxy.conf;
+        resolver 127.0.0.11 valid=30s;
+        set $upstream_qbittorrent qbittorrent;
+        proxy_pass http://$upstream_qbittorrent:8080;
+
+        proxy_set_header Host $upstream_qbittorrent:8080;
+    }
+}

--- a/qbittorrent.subfolder.conf.sample
+++ b/qbittorrent.subfolder.conf.sample
@@ -1,0 +1,22 @@
+# qbittorrent does not require a base url setting
+
+location /qbittorrent {
+    return 301 $scheme://$host/qbittorrent/;
+}
+location ^~ /qbittorrent/ {
+    # enable the next two lines for http auth
+    #auth_basic "Restricted";
+    #auth_basic_user_file /config/nginx/.htpasswd;
+
+    # enable the next two lines for ldap auth, also customize and enable ldap.conf in the default conf
+    #auth_request /auth;
+    #error_page 401 =200 /login;
+
+    include /config/nginx/proxy.conf;
+    resolver 127.0.0.11 valid=30s;
+    set $upstream_qbittorrent qbittorrent;
+    rewrite /qbittorrent(.*) $1 break;
+    proxy_pass http://$upstream_qbittorrent:8080;
+
+    proxy_set_header Host $upstream_qbittorrent:8080;
+}


### PR DESCRIPTION
Both tested and working. There is likely an API location that could be added but I have not found that yet.