### PR TITLE
fix websocket proxying

### DIFF
--- a/emby.subdomain.conf.sample
+++ b/emby.subdomain.conf.sample
@@ -1,6 +1,6 @@
 # make sure that your dns has a cname set for emby, if emby is running in bridge mode, the below config should work as is, although,
-# the container name is expected to be "emby", if not, replace the line "set $upstream_emby emby;" with "set $upstream_emby <containername>;"
-# for host mode, replace the line "proxy_pass http://$upstream_emby:8096;" with "proxy_pass http://HOSTIP:8096;" HOSTIP being the IP address of emby
+# the container name is expected to be "emby", if not, replace the lines "set $upstream_emby emby;" with "set $upstream_emby <containername>;"
+# for host mode, replace the lines "proxy_pass http://$upstream_emby:8096;" with "proxy_pass http://HOSTIP:8096;" HOSTIP being the IP address of emby
 # in emby settings, under "Advanced" change the public https port to 443, leave the local ports as is, set the "external domain" to your url,
 # and set the "Secure connection mode" to "Handled by reverse proxy"
 
@@ -19,9 +19,18 @@ server {
         resolver 127.0.0.11 valid=30s;
         set $upstream_emby emby;
         proxy_pass http://$upstream_emby:8096;
+		
         proxy_set_header Range $http_range;
         proxy_set_header If-Range $http_if_range;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
     }
+	
+    location ~ (/emby)?/socket {
+        include /config/nginx/proxy.conf;
+        resolver 127.0.0.11 valid=30s;
+        set $upstream_emby emby;
+        proxy_pass http://$upstream_emby:8096;
+		
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $http_connection;
+   }
 }

--- a/emby.subfolder.conf.sample
+++ b/emby.subfolder.conf.sample
@@ -1,6 +1,6 @@
 # if emby is running in bridge mode, the below config should work as is, although, the container name is expected to be "emby",
-# if not, replace the line "set $upstream_emby emby;" with "set $upstream_emby <containername>;"
-# for host mode, replace the line "proxy_pass http://$upstream_emby:8096;" with "proxy_pass http://HOSTIP:8096;" HOSTIP being the IP address of emby
+# if not, replace the lines "set $upstream_emby emby;" with "set $upstream_emby <containername>;"
+# for host mode, replace the lines "proxy_pass http://$upstream_emby:8096;" with "proxy_pass http://HOSTIP:8096;" HOSTIP being the IP address of emby
 # in emby settings, under "Advanced" change the public https port to 443, leave the local ports as is, set the "external domain" to your url and subdomain,
 # and set the "Secure connection mode" to "Handled by reverse proxy"
 
@@ -15,6 +15,14 @@ location ^~ /emby/ {
     
     proxy_set_header Range $http_range;
     proxy_set_header If-Range $http_if_range;
+}
+
+location ^~ /embywebsocket {
+    include /config/nginx/proxy.conf;
+    resolver 127.0.0.11 valid=30s;
+    set $upstream_emby emby;
+    proxy_pass http://$upstream_emby:8096;
+
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection $http_connection;
 }


### PR DESCRIPTION
This should fix the websocket HTTP 301 errors that were present in the dashboard.