### PR TITLE
Change upstream variable for new unifi-controller name.

### DIFF
--- a/unifi-controller.subdomain.conf.sample
+++ b/unifi-controller.subdomain.conf.sample
@@ -1,4 +1,4 @@
-# make sure that your dns has a cname set for unifi and that your unifi container is not using a base url
+# make sure that your dns has a cname set for unifi and that your unifi-controller container is not using a base url
 
 server {
     listen 443 ssl;

--- a/unifi.subdomain.conf.sample
+++ b/unifi.subdomain.conf.sample
@@ -24,7 +24,7 @@ server {
 
         include /config/nginx/proxy.conf;
         resolver 127.0.0.11 valid=30s;
-        set $upstream_unifi unifi;
+        set $upstream_unifi unifi-controller;
         proxy_pass https://$upstream_unifi:8443;
     }
 
@@ -39,7 +39,7 @@ server {
 
         include /config/nginx/proxy.conf;
         resolver 127.0.0.11 valid=30s;
-        set $upstream_unifi unifi;
+        set $upstream_unifi unifi-controller;
         proxy_pass https://$upstream_unifi:8443;
         proxy_buffering off;
         proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
As we're deprecating the old image and the new container is called unifi-controller.

@aptalca Unless you want to tackle this in a different way?