### PR TITLE
Added proxy_pass_header  X-Transmission-Session-Id;

### DIFF
--- a/transmission.subdomain.conf.sample
+++ b/transmission.subdomain.conf.sample
@@ -25,6 +25,7 @@ server {
         include /config/nginx/proxy.conf;
         resolver 127.0.0.11 valid=30s;
         set $upstream_transmission transmission;
+        proxy_pass_header  X-Transmission-Session-Id;
         proxy_pass http://$upstream_transmission:9091;
     }
 

--- a/transmission.subfolder.conf.sample
+++ b/transmission.subfolder.conf.sample
@@ -12,6 +12,7 @@ location ^~ /transmission {
     include /config/nginx/proxy.conf;
     resolver 127.0.0.11 valid=30s;
     set $upstream_transmission transmission;
+    proxy_pass_header  X-Transmission-Session-Id;
     proxy_pass http://$upstream_transmission:9091;
 }
 


### PR DESCRIPTION
I added "proxy_pass_header  X-Transmission-Session-Id;" to the tranmission subfolder config, it might also be needed for the subdomain, I simply don't know.

I had to add this to my config because I was getting a 409: Conflict error with the message that I had to pass this header to fix the error, I did and it fixed it.
I use rpc authentication, this might be the reason that I need this, but if I need to others might aswell