### PR TITLE
Added missing Collabora capabilities

### DIFF
--- a/collabora.subdomain.conf.sample
+++ b/collabora.subdomain.conf.sample
@@ -23,6 +23,12 @@ server {
         proxy_set_header Host $http_host;
     }
 
+    # Capabilities
+    location ^~ /hosting/capabilities {
+        proxy_pass https://$upstream_collabora:9980;
+        proxy_set_header Host $http_host;
+    }
+
     # main websocket
     location ~ ^/lool/(.*)/ws$ {
         proxy_pass https://$upstream_collabora:9980;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

This pull request add a missing location as described in the official proxy conf from Collabora. It enables the Nextcloud mobile app to function correctly with regard to opening Collabora documents.
https://www.collaboraoffice.com/code/nginx-reverse-proxy/