### PR TITLE
Enable HTTP Strict Transport Security.

### DIFF
--- a/nextcloud.subdomain.conf.sample
+++ b/nextcloud.subdomain.conf.sample
@@ -21,7 +21,9 @@ server {
     include /config/nginx/ssl.conf;
 
     client_max_body_size 0;
-
+    
+    add_header Strict-Transport-Security "max-age=15552000; includeSubDomains";
+    
     location / {
         include /config/nginx/proxy.conf;
         resolver 127.0.0.11 valid=30s;


### PR DESCRIPTION
This is added for security purposes and in order to suppress the "The "Strict-Transport-Security" HTTP header is not set to at least "15552000" seconds." warning in Nextcloud's security scan.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

