### PR TITLE
Fix comments on Plex configs

### DIFF
--- a/plex.subdomain.conf.sample
+++ b/plex.subdomain.conf.sample
@@ -1,5 +1,5 @@
 # make sure that your dns has a cname set for plex, if plex is running in bridge mode, the below config should work as is, for host mode,
-# replace the line "proxy_pass https://$upstream_plex:32400;" with "proxy_pass https://HOSTIP:32400;" HOSTIP being the IP address of plex
+# replace the line "proxy_pass http://$upstream_plex:32400;" with "proxy_pass http://HOSTIP:32400;" HOSTIP being the IP address of plex
 # in plex server settings, under network, fill in "Custom server access URLs" with your domain (ie. "https://plex.yourdomain.url:443")
 
 server {

--- a/plex.subfolder.conf.sample
+++ b/plex.subfolder.conf.sample
@@ -1,7 +1,7 @@
 # plex does not require a base url setting
 # if plex is running in bridge mode, the below config should work as is.
 # for host mode, replace the line "proxy_pass http://$upstream_plex:32400;" with "proxy_pass http://HOSTIP:32400;" HOSTIP being the IP address of plex
-# in plex server settings, under network, fill in "Custom server access URLs" with your domain (ie. "https://yourdomain.url/plex:443")
+# in plex server settings, under network, fill in "Custom server access URLs" with your domain (ie. "https://yourdomain.url:443/plex")
 
 location /plex {
     return 301 $scheme://$host/plex/;

--- a/plex.subfolder.conf.sample
+++ b/plex.subfolder.conf.sample
@@ -1,6 +1,6 @@
 # plex does not require a base url setting
-# if plex is running in bridge mode, the below config should work as is. 
-# for host mode, replace the line "proxy_pass https://$upstream_plex:32400;" with "proxy_pass https://HOSTIP:32400;" HOSTIP being the IP address of plex
+# if plex is running in bridge mode, the below config should work as is.
+# for host mode, replace the line "proxy_pass http://$upstream_plex:32400;" with "proxy_pass http://HOSTIP:32400;" HOSTIP being the IP address of plex
 # in plex server settings, under network, fill in "Custom server access URLs" with your domain (ie. "https://yourdomain.url/plex:443")
 
 location /plex {


### PR DESCRIPTION
The instruction comments say to replace the line with `https`, but later in the config file it uses `http` (which is correct).