### PR TITLE
Fix mytinytodo formatting

### DIFF
--- a/mytinytodo.subfolder.conf.sample
+++ b/mytinytodo.subfolder.conf.sample
@@ -1,19 +1,18 @@
 # works with https://github.com/breakall/mytinytodo-docker
 # set the mtt_url to 'https://your.domain.com/todo/' in db/config.php
 
-location ^~ /todo {
+location /todo {
     return 301 $scheme://$host/todo/;
 }
-
 location ^~ /todo/ {
 
     # enable the next two lines for http auth
-    # auth_basic "Restricted";
-    # auth_basic_user_file /config/nginx/.htpasswd;
+    #auth_basic "Restricted";
+    #auth_basic_user_file /config/nginx/.htpasswd;
 
     # enable the next two lines for ldap auth, also customize and enable ldap.conf in the default conf
-    # auth_request /auth;
-    # error_page 401 =200 /login;
+    #auth_request /auth;
+    #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
     resolver 127.0.0.11 valid=30s;


### PR DESCRIPTION
The top location block is adjusted to match the formatting of other location blocks performing the same redirect across the repo. The commented lines are adjusted to remove a space from the lines that have things that could be uncommented and used (where actual comments retain the space).

I came across this by running:
```bash
find . -type f -print0 | xargs -0 grep "\sauth_request /auth"
find . -type f -print0 | xargs -0 grep "\sauth_basic \"Restricted\""
```
Where I was actually trying to find configs in which I had enabled auth, but this config returned in the results due to the different formatting.