### PR TITLE
Dillinger Subdomain config

### DIFF
--- a/dillinger.subdomain.conf.sample
+++ b/dillinger.subdomain.conf.sample
@@ -1,0 +1,30 @@
+# make sure that your dns has a cname set for dillinger
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name dillinger.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    # enable for ldap auth, fill in ldap details in ldap.conf
+    #include /config/nginx/ldap.conf;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable the next two lines for ldap auth
+        #auth_request /auth;
+        #error_page 401 =200 /login;
+
+        include /config/nginx/proxy.conf;
+        resolver 127.0.0.11 valid=30s;
+        set $upstream_dillinger dillinger;
+        proxy_pass http://$upstream_dillinger:8080;
+    }
+}


### PR DESCRIPTION
I haven't been able to get subfolder working with docker networking.

This works without using docker networking.
```
location /dillinger/ {
    proxy_set_header Accept-Encoding "";
    proxy_set_header Host $http_host/app1;
    proxy_set_header X-Real-IP $remote_addr;
    proxy_set_header X-Scheme $scheme;
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
    proxy_set_header X-Forwarded-Proto $scheme;
    proxy_redirect    off;
    add_header Pragma "no-cache";
    add_header Cache-Control "no-cache";

    proxy_pass         http://${HOST_IP}:${HOST_PORT}/;
    sub_filter 'action="/'  'action="/dillinger/';
    sub_filter 'href="/'  'href="/dillinger/';
    sub_filter 'src="/'  'src="/dillinger/';
    sub_filter_once off;
}
```
But it's not exactly ideal.  I'll keep playing around.

