### PR TITLE
Remove ^~

### DIFF
--- a/airsonic.subfolder.conf.sample
+++ b/airsonic.subfolder.conf.sample
@@ -1,6 +1,6 @@
 # set the CONTEXT_PATH variable to /airsonic in airsonic container.
 
-location ^~ /airsonic {
+location /airsonic {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;

--- a/bazarr.subfolder.conf.sample
+++ b/bazarr.subfolder.conf.sample
@@ -3,7 +3,7 @@
 location /bazarr {
     return 301 $scheme://$host/bazarr/;
 }
-location ^~ /bazarr/ {
+location /bazarr/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;

--- a/collabora.subdomain.conf.sample
+++ b/collabora.subdomain.conf.sample
@@ -12,19 +12,19 @@ server {
     set $upstream_collabora collabora;
 
     # static files
-    location ^~ /loleaflet {
+    location /loleaflet {
         proxy_pass https://$upstream_collabora:9980;
         proxy_set_header Host $http_host;
     }
 
     # WOPI discovery URL
-    location ^~ /hosting/discovery {
+    location /hosting/discovery {
         proxy_pass https://$upstream_collabora:9980;
         proxy_set_header Host $http_host;
     }
 
     # Capabilities
-    location ^~ /hosting/capabilities {
+    location /hosting/capabilities {
         proxy_pass https://$upstream_collabora:9980;
         proxy_set_header Host $http_host;
     }
@@ -45,7 +45,7 @@ server {
     }
 
     # Admin Console websocket
-    location ^~ /lool/adminws {
+    location /lool/adminws {
         proxy_pass https://$upstream_collabora:9980;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";

--- a/couchpotato.subfolder.conf.sample
+++ b/couchpotato.subfolder.conf.sample
@@ -1,6 +1,6 @@
 # first go into couchpotato settings, under "General" set the URL Base to /couchpotato and restart the couchpotato container
 
-location ^~ /couchpotato {
+location /couchpotato {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;

--- a/deluge.subfolder.conf.sample
+++ b/deluge.subfolder.conf.sample
@@ -3,7 +3,7 @@
 location /deluge {
     return 301 $scheme://$host/deluge/;
 }
-location ^~ /deluge/ {
+location /deluge/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;

--- a/domoticz.subfolder.conf.sample
+++ b/domoticz.subfolder.conf.sample
@@ -1,6 +1,6 @@
 # set the WEBROOT variable to domoticz for the domoticz container.
 
-location ^~ /domoticz/ {
+location /domoticz/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;

--- a/duplicati.subfolder.conf.sample
+++ b/duplicati.subfolder.conf.sample
@@ -3,7 +3,7 @@
 location /duplicati {
     return 301 $scheme://$host/duplicati/;
 }
-location ^~ /duplicati/ {
+location /duplicati/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;

--- a/emby.subfolder.conf.sample
+++ b/emby.subfolder.conf.sample
@@ -7,7 +7,7 @@
 location /emby {
     return 301 $scheme://$host/emby/;
 }
-location ^~ /emby/ {
+location /emby/ {
     include /config/nginx/proxy.conf;
     resolver 127.0.0.11 valid=30s;
     set $upstream_emby emby;
@@ -17,7 +17,7 @@ location ^~ /emby/ {
     proxy_set_header If-Range $http_if_range;
 }
 
-location ^~ /embywebsocket {
+location /embywebsocket {
     include /config/nginx/proxy.conf;
     resolver 127.0.0.11 valid=30s;
     set $upstream_emby emby;

--- a/flood.subfolder.conf.sample
+++ b/flood.subfolder.conf.sample
@@ -3,7 +3,7 @@
 location /flood {
     return 301 $scheme://$host/flood/;
 }
-location ^~ /flood/ {
+location /flood/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;

--- a/gitea.subfolder.conf.sample
+++ b/gitea.subfolder.conf.sample
@@ -8,7 +8,7 @@ location /gitea {
     return 301 $scheme://$host/gitea/;
 }
 
-location ^~ /gitea/ {
+location /gitea/ {
     include /config/nginx/proxy.conf;
     resolver 127.0.0.11 valid=30s;
     set $upstream_gitea gitea;

--- a/glances.subfolder.conf.sample
+++ b/glances.subfolder.conf.sample
@@ -3,7 +3,7 @@
 location /glances {
     return 301 $scheme://$host/glances/;
 }
-location ^~ /glances/ {
+location /glances/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;

--- a/guacamole.subfolder.conf.sample
+++ b/guacamole.subfolder.conf.sample
@@ -3,7 +3,7 @@
 location /guacamole {
     return 301 $scheme://$host/guacamole/;
 }
-location ^~ /guacamole/ {
+location /guacamole/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;

--- a/headphones.subfolder.conf.sample
+++ b/headphones.subfolder.conf.sample
@@ -1,6 +1,6 @@
 # first stop the headphones container and edit the config.ini for headphones and set http_root to /headphones and then start the headphones container
 
-location ^~ /headphones {
+location /headphones {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;

--- a/kanzi.subfolder.conf.sample
+++ b/kanzi.subfolder.conf.sample
@@ -3,7 +3,7 @@
 location /kanzi {
     return 301 $scheme://$host/kanzi/;
 }
-location ^~ /kanzi/ {
+location /kanzi/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;

--- a/lazylibrarian.subfolder.conf.sample
+++ b/lazylibrarian.subfolder.conf.sample
@@ -1,6 +1,6 @@
 # first go into lazylibrarian settings, under "Interface" set the URL Base to /lazylibrarian and restart the lazylibrarian container
 
-location ^~ /lazylibrarian {
+location /lazylibrarian {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;

--- a/lidarr.subfolder.conf.sample
+++ b/lidarr.subfolder.conf.sample
@@ -1,6 +1,6 @@
 # first go into lidarr settings, under "General" set the URL Base to /lidarr and restart the lidarr container
 
-location ^~ /lidarr {
+location /lidarr {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
@@ -15,7 +15,7 @@ location ^~ /lidarr {
     proxy_pass http://$upstream_lidarr:8686;
 }
 
-location ^~ /lidarr/api {
+location /lidarr/api {
     include /config/nginx/proxy.conf;
     resolver 127.0.0.11 valid=30s;
     set $upstream_lidarr lidarr;

--- a/medusa.subfolder.conf.sample
+++ b/medusa.subfolder.conf.sample
@@ -1,6 +1,6 @@
 # first go into medusa settings, under "Interface" set the URL Base to /medusa and restart the medusa container
 
-location ^~ /medusa {
+location /medusa {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;

--- a/monitorr.subfolder.conf.sample
+++ b/monitorr.subfolder.conf.sample
@@ -3,7 +3,7 @@
 location /monitorr {
     return 301 $scheme://$host/monitorr/;
 }
-location ^~ /monitorr/ {
+location /monitorr/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;

--- a/mylar.subfolder.conf.sample
+++ b/mylar.subfolder.conf.sample
@@ -1,6 +1,6 @@
 # first stop the mylar container and edit the config.ini for mylar and set http_root to /mylar and then start the mylar container
 
-location ^~ /mylar {
+location /mylar {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;

--- a/mytinytodo.subfolder.conf.sample
+++ b/mytinytodo.subfolder.conf.sample
@@ -1,11 +1,11 @@
 # works with https://github.com/breakall/mytinytodo-docker
 # set the mtt_url to 'https://your.domain.com/todo/' in db/config.php
 
-location ^~ /todo {
+location /todo {
     return 301 $scheme://$host/todo/;
 }
 
-location ^~ /todo/ {
+location /todo/ {
 
     # enable the next two lines for http auth
     # auth_basic "Restricted";

--- a/netdata.subfolder.conf.sample
+++ b/netdata.subfolder.conf.sample
@@ -3,7 +3,7 @@
 location /netdata {
     return 301 $scheme://$host/netdata/;
 }
-location ^~ /netdata/ {
+location /netdata/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;

--- a/nextcloud.subfolder.conf.sample
+++ b/nextcloud.subfolder.conf.sample
@@ -23,7 +23,7 @@ location /nextcloud {
     return 301 $scheme://$host/nextcloud/;
 }
 
-location ^~ /nextcloud/ {
+location /nextcloud/ {
     include /config/nginx/proxy.conf;
     resolver 127.0.0.11 valid=30s;
     set $upstream_nextcloud nextcloud;

--- a/nzbget.subfolder.conf.sample
+++ b/nzbget.subfolder.conf.sample
@@ -1,6 +1,6 @@
 # nzbget does not require a base url setting
 
-location ^~ /nzbget {
+location /nzbget {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;

--- a/nzbhydra.subfolder.conf.sample
+++ b/nzbhydra.subfolder.conf.sample
@@ -1,6 +1,6 @@
 # first go into nzbhydra settings, set the URL Base to /nzbhydra, then disable CSRF protection on the same page and restart the nzbhydra container
 
-location ^~ /nzbhydra {
+location /nzbhydra {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
@@ -15,7 +15,7 @@ location ^~ /nzbhydra {
     proxy_pass http://$upstream_nzbhydra:5076;
 }
 
-location ^~ /nzbhydra/api {
+location /nzbhydra/api {
     include /config/nginx/proxy.conf;
     resolver 127.0.0.11 valid=30s;
     set $upstream_nzbhydra hydra2;

--- a/ombi.subfolder.conf.sample
+++ b/ombi.subfolder.conf.sample
@@ -4,7 +4,7 @@ location /ombi {
     return 301 $scheme://$host/ombi/;
 }
 
-location ^~ /ombi/ {
+location /ombi/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
@@ -20,7 +20,7 @@ location ^~ /ombi/ {
 }
 
 # This allows access to the actual api
-location ^~ /ombi/api {
+location /ombi/api {
     include /config/nginx/proxy.conf;
     resolver 127.0.0.11 valid=30s;
     set $upstream_ombi ombi;
@@ -31,7 +31,7 @@ if ($http_referer ~* /ombi) {
 }
 
 # This allows access to the documentation for the api
-location ^~ /ombi/swagger {
+location /ombi/swagger {
     include /config/nginx/proxy.conf;
     resolver 127.0.0.11 valid=30s;
     set $upstream_ombi ombi;

--- a/phpmyadmin.subfolder.conf.sample
+++ b/phpmyadmin.subfolder.conf.sample
@@ -3,7 +3,7 @@
 location /phpmyadmin {
     return 301 $scheme://$host/phpmyadmin/;
 }
-location ^~ /phpmyadmin/ {
+location /phpmyadmin/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;

--- a/pihole.subfolder.conf.sample
+++ b/pihole.subfolder.conf.sample
@@ -3,7 +3,7 @@
 location /pihole {
     return 301 $scheme://$host/pihole/;
 }
-location ^~ /pihole/ {
+location /pihole/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
@@ -23,7 +23,7 @@ location ^~ /pihole/ {
 location /pihole/admin {
     return 301 $scheme://$host/pihole/admin/;
 }
-location ^~ /pihole/admin/ {
+location /pihole/admin/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;

--- a/plex.subfolder.conf.sample
+++ b/plex.subfolder.conf.sample
@@ -6,7 +6,7 @@
 location /plex {
     return 301 $scheme://$host/plex/;
 }
-location ^~ /plex/ {
+location /plex/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;

--- a/plexwebtools.subfolder.conf.sample
+++ b/plexwebtools.subfolder.conf.sample
@@ -3,7 +3,7 @@
 location /plexwebtools {
     return 301 $scheme://$host/plexwebtools/;
 }
-location ^~ /plexwebtools/ {
+location /plexwebtools/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;

--- a/portainer.subfolder.conf.sample
+++ b/portainer.subfolder.conf.sample
@@ -3,7 +3,7 @@
 location /portainer {
     return 301 $scheme://$host/portainer/;
 }
-location ^~ /portainer/ {
+location /portainer/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
@@ -20,7 +20,7 @@ location ^~ /portainer/ {
     proxy_hide_header X-Frame-Options; # Possibly nott needed after Portainer 1.20.0
 }
 
-location ^~ /portainer/api/websocket/ {
+location /portainer/api/websocket/ {
     include /config/nginx/proxy.conf;
     resolver 127.0.0.11 valid=30s;
     set $upstream_portainer portainer;

--- a/qbittorrent.subfolder.conf.sample
+++ b/qbittorrent.subfolder.conf.sample
@@ -3,7 +3,7 @@
 location /qbittorrent {
     return 301 $scheme://$host/qbittorrent/;
 }
-location ^~ /qbittorrent/ {
+location /qbittorrent/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;

--- a/quassel-web.subfolder.conf.sample
+++ b/quassel-web.subfolder.conf.sample
@@ -1,7 +1,7 @@
 # Set base-url with docker run command env variable -e 'URL_BASE'='/quassel' and make sure Quassel-Web is running on http 
 # with -e 'HTTPS'='false' or if you're using -e 'ADVANCED'='true' by editing config.json appropriately
 
-location ^~ /quassel {
+location /quassel {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;

--- a/radarr.subfolder.conf.sample
+++ b/radarr.subfolder.conf.sample
@@ -1,6 +1,6 @@
 # first go into radarr settings, under "General" set the URL Base to /radarr and restart the radarr container
 
-location ^~ /radarr {
+location /radarr {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
@@ -15,7 +15,7 @@ location ^~ /radarr {
     proxy_pass http://$upstream_radarr:7878;
 }
 
-location ^~ /radarr/api {
+location /radarr/api {
     include /config/nginx/proxy.conf;
     resolver 127.0.0.11 valid=30s;
     set $upstream_radarr radarr;

--- a/rutorrent.subfolder.conf.sample
+++ b/rutorrent.subfolder.conf.sample
@@ -3,7 +3,7 @@
 location /rutorrent {
     return 301 $scheme://$host/rutorrent/;
 }
-location ^~ /rutorrent/ {
+location /rutorrent/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
@@ -19,7 +19,7 @@ location ^~ /rutorrent/ {
     proxy_pass http://$upstream_rutorrent:80;
 }
 
-location ^~ /rutorrent/RPC2 {
+location /rutorrent/RPC2 {
     include /config/nginx/proxy.conf;
     resolver 127.0.0.11 valid=30s;
     set $upstream_rutorrent rutorrent;

--- a/sabnzbd.subfolder.conf.sample
+++ b/sabnzbd.subfolder.conf.sample
@@ -1,6 +1,6 @@
 # sabnzbd already uses the base url /sabnzbd by default so you don't need to do anything extra
 
-location ^~ /sabnzbd {
+location /sabnzbd {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
@@ -15,7 +15,7 @@ location ^~ /sabnzbd {
     proxy_pass http://$upstream_sabnzbd:8080;
 }
 
-location ^~ /sabnzbd/api {
+location /sabnzbd/api {
     include /config/nginx/proxy.conf;
     resolver 127.0.0.11 valid=30s;
     set $upstream_sabnzbd sabnzbd;

--- a/sickrage.subfolder.conf.sample
+++ b/sickrage.subfolder.conf.sample
@@ -1,6 +1,6 @@
 # first stop the sickrage container and edit the config.ini for sickrage and set web_root to /sickrage and then start the sickrage container
 
-location ^~ /sickrage {
+location /sickrage {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;

--- a/sonarr.subfolder.conf.sample
+++ b/sonarr.subfolder.conf.sample
@@ -1,6 +1,6 @@
 # first go into sonarr settings, under "General" set the URL Base to /sonarr and restart the sonarr container
 
-location ^~ /sonarr {
+location /sonarr {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
@@ -15,7 +15,7 @@ location ^~ /sonarr {
     proxy_pass http://$upstream_sonarr:8989;
 }
 
-location ^~ /sonarr/api {
+location /sonarr/api {
     include /config/nginx/proxy.conf;
     resolver 127.0.0.11 valid=30s;
     set $upstream_sonarr sonarr;

--- a/tautulli.subfolder.conf.sample
+++ b/tautulli.subfolder.conf.sample
@@ -1,6 +1,6 @@
 # first go into tautulli settings, under "Web Interface", click on show advanced, set the HTTP root to /tautulli and restart the tautulli container
 
-location ^~ /tautulli {
+location /tautulli {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
@@ -15,7 +15,7 @@ location ^~ /tautulli {
     proxy_pass http://$upstream_tautulli:8181;
 }
 
-location ^~ /tautulli/api {
+location /tautulli/api {
     include /config/nginx/proxy.conf;
     resolver 127.0.0.11 valid=30s;
     set $upstream_tautulli tautulli;

--- a/thelounge.subfolder.conf.sample
+++ b/thelounge.subfolder.conf.sample
@@ -3,7 +3,7 @@
 location /thelounge {
     return 301 $scheme://$host/thelounge/;
 }
-location ^~ /thelounge/ {
+location /thelounge/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;

--- a/transmission.subfolder.conf.sample
+++ b/transmission.subfolder.conf.sample
@@ -1,6 +1,6 @@
 # transmission does not require a base url setting
 
-location ^~ /transmission {
+location /transmission {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
@@ -16,7 +16,7 @@ location ^~ /transmission {
     proxy_pass http://$upstream_transmission:9091;
 }
 
-location ^~ /transmission/rpc {
+location /transmission/rpc {
     include /config/nginx/proxy.conf;
     resolver 127.0.0.11 valid=30s;
     set $upstream_transmission transmission;

--- a/ubooquity.subfolder.conf.sample
+++ b/ubooquity.subfolder.conf.sample
@@ -1,6 +1,6 @@
 # set the reverse proxy prefix in the admin gui to ubooquity.
 
-    location ^~ /ubooquity {
+    location /ubooquity {
         # enable the next two lines for http auth
         #auth_basic "Restricted";
         #auth_basic_user_file /config/nginx/.htpasswd;
@@ -15,7 +15,7 @@
         proxy_pass http://$upstream_ubooquity:2202;
     }
 
-    location ^~ /ubooquity/admin {
+    location /ubooquity/admin {
         include /config/nginx/proxy.conf;
         resolver 127.0.0.11 valid=30s;
         set $upstream_ubooquity ubooquity;


### PR DESCRIPTION
http://nginx.org/en/docs/http/ngx_http_core_module.html#location

> If the longest matching prefix location has the “^~” modifier then regular expressions are not checked.

I've run into a issue specifically with the nzbget proxy config where this `^~` modifier prevented nzb360 from accessing the RPC URLs when an `auth_request` directive was used in the main location block (ex: ldap or Organizr auth). I have tested about 1/4 of these, but based on the documentation I don't see a need for them. It seems like these were mostly included because a small number of configs had them (traced back to radarr https://github.com/linuxserver/docker-letsencrypt/commit/ac896d056e3fbd6b5e25d7506a32bcd04dd7db65, which I have confirmed doesn't need it) and many configs created after that just did a copy/replace job (I did many of them) and stayed in line with existing formatting in the repo.

If this isn't going to be accepted I'll make a PR specifically for only nzbget.