### PR TITLE
Add non-auth locations for qbittorrent

### DIFF
--- a/qbittorrent.subdomain.conf.sample
+++ b/qbittorrent.subdomain.conf.sample
@@ -30,4 +30,59 @@ server {
         proxy_set_header Referer '';
         proxy_set_header Host $upstream_qbittorrent:8080;
     }
+
+    location ^~ /qbittorrent/api {
+        include /config/nginx/proxy.conf;
+        resolver 127.0.0.11 valid=30s;
+        set $upstream_qbittorrent qbittorrent;
+        rewrite /qbittorrent(.*) $1 break;
+        proxy_pass http://$upstream_qbittorrent:8080;
+
+        proxy_set_header Referer '';
+        proxy_set_header Host $upstream_qbittorrent:8080;
+    }
+
+    location ^~ /qbittorrent/command {
+        include /config/nginx/proxy.conf;
+        resolver 127.0.0.11 valid=30s;
+        set $upstream_qbittorrent qbittorrent;
+        rewrite /qbittorrent(.*) $1 break;
+        proxy_pass http://$upstream_qbittorrent:8080;
+
+        proxy_set_header Referer '';
+        proxy_set_header Host $upstream_qbittorrent:8080;
+    }
+
+    location ^~ /qbittorrent/query {
+        include /config/nginx/proxy.conf;
+        resolver 127.0.0.11 valid=30s;
+        set $upstream_qbittorrent qbittorrent;
+        rewrite /qbittorrent(.*) $1 break;
+        proxy_pass http://$upstream_qbittorrent:8080;
+
+        proxy_set_header Referer '';
+        proxy_set_header Host $upstream_qbittorrent:8080;
+    }
+
+    location ^~ /qbittorrent/login {
+        include /config/nginx/proxy.conf;
+        resolver 127.0.0.11 valid=30s;
+        set $upstream_qbittorrent qbittorrent;
+        rewrite /qbittorrent(.*) $1 break;
+        proxy_pass http://$upstream_qbittorrent:8080;
+
+        proxy_set_header Referer '';
+        proxy_set_header Host $upstream_qbittorrent:8080;
+    }
+
+    location ^~ /qbittorrent/sync {
+        include /config/nginx/proxy.conf;
+        resolver 127.0.0.11 valid=30s;
+        set $upstream_qbittorrent qbittorrent;
+        rewrite /qbittorrent(.*) $1 break;
+        proxy_pass http://$upstream_qbittorrent:8080;
+
+        proxy_set_header Referer '';
+        proxy_set_header Host $upstream_qbittorrent:8080;
+    }
 }

--- a/qbittorrent.subfolder.conf.sample
+++ b/qbittorrent.subfolder.conf.sample
@@ -21,3 +21,58 @@ location ^~ /qbittorrent/ {
     proxy_set_header Referer '';
     proxy_set_header Host $upstream_qbittorrent:8080;
 }
+
+location ^~ /qbittorrent/api {
+    include /config/nginx/proxy.conf;
+    resolver 127.0.0.11 valid=30s;
+    set $upstream_qbittorrent qbittorrent;
+    rewrite /qbittorrent(.*) $1 break;
+    proxy_pass http://$upstream_qbittorrent:8080;
+
+    proxy_set_header Referer '';
+    proxy_set_header Host $upstream_qbittorrent:8080;
+}
+
+location ^~ /qbittorrent/command {
+    include /config/nginx/proxy.conf;
+    resolver 127.0.0.11 valid=30s;
+    set $upstream_qbittorrent qbittorrent;
+    rewrite /qbittorrent(.*) $1 break;
+    proxy_pass http://$upstream_qbittorrent:8080;
+
+    proxy_set_header Referer '';
+    proxy_set_header Host $upstream_qbittorrent:8080;
+}
+
+location ^~ /qbittorrent/query {
+    include /config/nginx/proxy.conf;
+    resolver 127.0.0.11 valid=30s;
+    set $upstream_qbittorrent qbittorrent;
+    rewrite /qbittorrent(.*) $1 break;
+    proxy_pass http://$upstream_qbittorrent:8080;
+
+    proxy_set_header Referer '';
+    proxy_set_header Host $upstream_qbittorrent:8080;
+}
+
+location ^~ /qbittorrent/login {
+    include /config/nginx/proxy.conf;
+    resolver 127.0.0.11 valid=30s;
+    set $upstream_qbittorrent qbittorrent;
+    rewrite /qbittorrent(.*) $1 break;
+    proxy_pass http://$upstream_qbittorrent:8080;
+
+    proxy_set_header Referer '';
+    proxy_set_header Host $upstream_qbittorrent:8080;
+}
+
+location ^~ /qbittorrent/sync {
+    include /config/nginx/proxy.conf;
+    resolver 127.0.0.11 valid=30s;
+    set $upstream_qbittorrent qbittorrent;
+    rewrite /qbittorrent(.*) $1 break;
+    proxy_pass http://$upstream_qbittorrent:8080;
+
+    proxy_set_header Referer '';
+    proxy_set_header Host $upstream_qbittorrent:8080;
+}


### PR DESCRIPTION
These locations allow nzb360 to access qbit without auth (same as most other `/api` locations in other confs).