### PR TITLE
Fix tt-rss subdomain redirection

### DIFF
--- a/tt-rss.subdomain.conf.sample
+++ b/tt-rss.subdomain.conf.sample
@@ -2,12 +2,6 @@
 # In tt-rss config.php the SELF_URL_PATH should be set to http://tt-rss.server.com/ NOT https://tt-rss.server.com although it will be accessible on https://tt-rss.server.com
 
 server {
-    listen 80;
-        server_name tt-rss.*;
-        return 301 https://$host$request_uri;
-}
-
-server {
     listen 443 ssl;
     listen [::]:443 ssl;
 

--- a/tt-rss.subdomain.conf.sample
+++ b/tt-rss.subdomain.conf.sample
@@ -4,7 +4,7 @@
 server {
     listen 80;
         server_name tt-rss.*;
-        return 301 https://$server_name$request_uri;
+        return 301 https://$host$request_uri;
 }
 
 server {


### PR DESCRIPTION
I was having an issue where attempting to login to tt-rss was redirecting me to "https://tt-rss.%2a/index.php" instead of the expected "https://tt-rss.mydomain.com/index.php". I tracked the issue down to this line in the tt-rss.subdomain.conf file.

I believe $host and not $server_name should be used here.