### PR TITLE
Add Nextcloud recommended security options

### DIFF
--- a/nextcloud.subdomain.conf.sample
+++ b/nextcloud.subdomain.conf.sample
@@ -21,6 +21,9 @@ server {
     include /config/nginx/ssl.conf;
 
     client_max_body_size 0;
+    
+    add_header X-Frame-Options "SAMEORIGIN";
+    add_header Strict-Transport-Security "max-age=15552000" always;
 
     location / {
         include /config/nginx/proxy.conf;


### PR DESCRIPTION
There were 2 security options recommended by Nextcloud under the "Security & setup warnings" page. I have implemented both of those recommendations into this config.