### PR TITLE
rootfolder for Heimdall and Organizr

### DIFF
--- a/heimdall.rootfolder.conf.sample
+++ b/heimdall.rootfolder.conf.sample
@@ -1,4 +1,4 @@
-# In order to use this location block you need to edit the default file one folder up and comment out the / location
+# Only use one rootfolder conf at a time!
 
 location / {
     # enable the next two lines for http auth

--- a/organizr.rootfolder.conf.sample
+++ b/organizr.rootfolder.conf.sample
@@ -1,4 +1,4 @@
-# In order to use this location block you need to edit the default file one folder up and comment out the / location
+# Only use one rootfolder conf at a time!
 
 location / {
     # enable the next two lines for http auth


### PR DESCRIPTION
https://github.com/linuxserver/docker-letsencrypt/pull/366

The goal of this change is to simplify how users enable the Heimdall and Organizr proxy configs. Out of the box they are not setup to use subfolders but rather instruct the user to comment out the root location in the default site config in order to use the selected proxy. These changes would negate the need to change the default site config and allow users to simply rename the appropriate file. Separate subfolder proxy configs can be created to actually put Heimdall and Organizr on /heimdall and /organizr if needed.

P.S. I have tested and confirmed this works for me :tm: