### PR TITLE
Update sabnzbd.subdomain.conf.sample

### DIFF
--- a/sabnzbd.subdomain.conf.sample
+++ b/sabnzbd.subdomain.conf.sample
@@ -1,4 +1,6 @@
 # make sure that your dns has a cname set for sabnzbd
+# edit the sabnzbd.ini to sub.domain.tld to the host_whitelist to avoid hostname verification issues. This format:
+# host_whitelist = sabnzbd.domain.com, www.sabnzbd.domain.com
 
 server {
     listen 443 ssl;

--- a/sabnzbd.subdomain.conf.sample
+++ b/sabnzbd.subdomain.conf.sample
@@ -1,5 +1,5 @@
 # make sure that your dns has a cname set for sabnzbd
-# edit the sabnzbd.ini to sub.domain.tld to the host_whitelist to avoid hostname verification issues. This format:
+# edit the sabnzbd.ini host_whitelist to avoid hostname verification issues. This format:
 # host_whitelist = sabnzbd.domain.com, www.sabnzbd.domain.com
 
 server {


### PR DESCRIPTION
sabnzbd introduced hostname verification in 2.3.3  It is now  necessary to add the external URL to the "host_whitelist" or you'll get an error upon loading linuxserver/sabnzbd container using the sabnzbd.subdomain.conf configuration. 
https://sabnzbd.org/wiki/extra/hostname-check.html

