### PR TITLE
Remove resolver from proxy confs

### DIFF
--- a/adguard.subdomain.conf.sample
+++ b/adguard.subdomain.conf.sample
@@ -23,7 +23,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_adguard adguard;
         proxy_pass http://$upstream_adguard;
     }

--- a/adminer.subfolder.conf.sample
+++ b/adminer.subfolder.conf.sample
@@ -13,7 +13,6 @@ location ^~ /adminer/ {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_adminer adminer;
     proxy_pass http://$upstream_adminer:8080;
 }

--- a/airsonic.subdomain.conf.sample
+++ b/airsonic.subdomain.conf.sample
@@ -21,9 +21,8 @@ server {
         # enable the next two lines for ldap auth
         #auth_request /auth;
         #error_page 401 =200 /login;
-        
+
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_airsonic airsonic;
         proxy_pass http://$upstream_airsonic:4040;
     }

--- a/airsonic.subfolder.conf.sample
+++ b/airsonic.subfolder.conf.sample
@@ -10,7 +10,6 @@ location ^~ /airsonic {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_airsonic airsonic;
     proxy_pass http://$upstream_airsonic:4040;
 }

--- a/bazarr.subdomain.conf.sample
+++ b/bazarr.subdomain.conf.sample
@@ -23,7 +23,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_bazarr bazarr;
         proxy_pass http://$upstream_bazarr:6767;
     }

--- a/bazarr.subfolder.conf.sample
+++ b/bazarr.subfolder.conf.sample
@@ -13,7 +13,6 @@ location ^~ /bazarr/ {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_bazarr bazarr;
     proxy_pass http://$upstream_bazarr:6767;
 }

--- a/beets.subdomain.conf.sample
+++ b/beets.subdomain.conf.sample
@@ -1,4 +1,4 @@
-#First edit beets.yml and enable the reverse proxy settings, under "web" add "reverse_proxy: true" and restart the beets container. 
+#First edit beets.yml and enable the reverse proxy settings, under "web" add "reverse_proxy: true" and restart the beets container.
 #Make sure that your dns has a cname set for beets and that your beets container is not using a base url
 
 server {
@@ -24,7 +24,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_beets beets;
         proxy_pass http://$upstream_beets:8337;
     }

--- a/beets.subfolder.conf.sample
+++ b/beets.subfolder.conf.sample
@@ -10,7 +10,6 @@ location /beets {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_beets beets;
     proxy_pass http://$upstream_beets:8337;
     proxy_set_header Host $host;

--- a/bitwarden.subdomain.conf.sample
+++ b/bitwarden.subdomain.conf.sample
@@ -23,14 +23,12 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_bitwarden bitwarden;
         proxy_pass http://$upstream_bitwarden:80;
     }
 
     location /notifications/hub {
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_bitwarden bitwarden;
         proxy_pass http://$upstream_bitwarden:80;
         proxy_set_header Upgrade $http_upgrade;
@@ -39,7 +37,6 @@ server {
 
     location /notifications/hub/negotiate {
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_bitwarden bitwarden;
         proxy_pass http://$upstream_bitwarden:80;
     }

--- a/calibre-web.subfolder.conf.sample
+++ b/calibre-web.subfolder.conf.sample
@@ -12,7 +12,6 @@ location ^~ /calibre-web/ {
     #auth_request /auth;
     #error_page 401 =200 /login;
 
-    resolver 127.0.0.11 valid=30s;
     set $upstream_calibre_web calibre-web;
     proxy_pass http://$upstream_calibre_web:8083;
     proxy_set_header Host $http_host;

--- a/calibre.subdomain.conf.sample
+++ b/calibre.subdomain.conf.sample
@@ -22,7 +22,6 @@ server {
         #auth_request /auth;
         #error_page 401 =200 /login;
 
-        resolver 127.0.0.11 valid=30s;
         set $upstream_calibre calibre;
         proxy_pass http://$upstream_calibre:8080;
         proxy_buffering off;

--- a/calibre.subfolder.conf.sample
+++ b/calibre.subfolder.conf.sample
@@ -1,4 +1,4 @@
-# calibre does not require a base url setting 
+# calibre does not require a base url setting
 
 location /calibre {
     return 301 $scheme://$host/calibre/;
@@ -12,7 +12,6 @@ location ^~ /calibre/ {
     #auth_request /auth;
     #error_page 401 =200 /login;
 
-    resolver 127.0.0.11 valid=30s;
     set $upstream_calibre calibre;
     rewrite /calibre(.*) $1 break;
     proxy_pass http://$upstream_calibre:8080;

--- a/code-server.subdomain.conf.sample
+++ b/code-server.subdomain.conf.sample
@@ -23,7 +23,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_code_server code-server;
         proxy_pass http://$upstream_code_server:8443;
         proxy_set_header Upgrade $http_upgrade;

--- a/codimd.subdomain.conf.sample
+++ b/codimd.subdomain.conf.sample
@@ -25,7 +25,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_codimd codimd;
         proxy_pass http://$upstream_codimd:3000;
     }

--- a/collabora.subdomain.conf.sample
+++ b/collabora.subdomain.conf.sample
@@ -8,7 +8,6 @@ server {
 
     include /config/nginx/ssl.conf;
 
-    resolver 127.0.0.11 valid=30s;
     set $upstream_collabora collabora;
 
     # static files

--- a/couchpotato.subdomain.conf.sample
+++ b/couchpotato.subdomain.conf.sample
@@ -23,7 +23,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_couchpotato couchpotato;
         proxy_pass http://$upstream_couchpotato:5050;
     }

--- a/couchpotato.subfolder.conf.sample
+++ b/couchpotato.subfolder.conf.sample
@@ -10,7 +10,6 @@ location ^~ /couchpotato {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_couchpotato couchpotato;
     proxy_pass http://$upstream_couchpotato:5050;
 }

--- a/deluge.subdomain.conf.sample
+++ b/deluge.subdomain.conf.sample
@@ -23,7 +23,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_deluge deluge;
         proxy_pass http://$upstream_deluge:8112;
     }

--- a/deluge.subfolder.conf.sample
+++ b/deluge.subfolder.conf.sample
@@ -13,7 +13,6 @@ location ^~ /deluge/ {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_deluge deluge;
     rewrite /deluge(.*) $1 break;
     proxy_pass http://$upstream_deluge:8112;

--- a/dillinger.subdomain.conf.sample
+++ b/dillinger.subdomain.conf.sample
@@ -23,7 +23,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_dillinger dillinger;
         proxy_pass http://$upstream_dillinger:8080;
     }

--- a/dokuwiki.subdomain.conf.sample
+++ b/dokuwiki.subdomain.conf.sample
@@ -1,4 +1,4 @@
-# First complete the setup by appending install.php to URL. 
+# First complete the setup by appending install.php to URL.
 # Make sure that your dns has a cname set for dokuwiki
 
 server {
@@ -24,7 +24,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_dokuwiki dokuwiki;
         proxy_pass http://$upstream_dokuwiki:80;
     }

--- a/domoticz.subdomain.conf.sample
+++ b/domoticz.subdomain.conf.sample
@@ -23,7 +23,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_domoticz domoticz;
         proxy_pass http://$upstream_domoticz:8080;
     }

--- a/domoticz.subfolder.conf.sample
+++ b/domoticz.subfolder.conf.sample
@@ -10,7 +10,6 @@ location ^~ /domoticz/ {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_domoticz domoticz;
     proxy_pass http://$upstream_domoticz:8080;
 }

--- a/duplicati.subdomain.conf.sample
+++ b/duplicati.subdomain.conf.sample
@@ -22,7 +22,6 @@ server {
         #auth_request /auth;
         #error_page 401 =200 /login;
 
-        resolver 127.0.0.11 valid=30s;
         set $upstream_duplicati duplicati;
         proxy_pass http://$upstream_duplicati:8200;
     }

--- a/duplicati.subfolder.conf.sample
+++ b/duplicati.subfolder.conf.sample
@@ -12,7 +12,6 @@ location ^~ /duplicati/ {
     #auth_request /auth;
     #error_page 401 =200 /login;
 
-    resolver 127.0.0.11 valid=30s;
     set $upstream_duplicati duplicati;
     rewrite /duplicati(.*) $1 break;
     proxy_pass http://$upstream_duplicati:8200;

--- a/emby.subdomain.conf.sample
+++ b/emby.subdomain.conf.sample
@@ -16,20 +16,18 @@ server {
 
     location / {
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_emby emby;
         proxy_pass http://$upstream_emby:8096;
-		
+
         proxy_set_header Range $http_range;
         proxy_set_header If-Range $http_if_range;
     }
-	
+
     location ~ (/emby)?/socket {
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_emby emby;
         proxy_pass http://$upstream_emby:8096;
-		
+
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $http_connection;
    }

--- a/emby.subfolder.conf.sample
+++ b/emby.subfolder.conf.sample
@@ -9,17 +9,15 @@ location /emby {
 }
 location ^~ /emby/ {
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_emby emby;
     proxy_pass http://$upstream_emby:8096;
-    
+
     proxy_set_header Range $http_range;
     proxy_set_header If-Range $http_if_range;
 }
 
 location ^~ /embywebsocket {
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_emby emby;
     proxy_pass http://$upstream_emby:8096;
 

--- a/embystat.subdomain.conf.sample
+++ b/embystat.subdomain.conf.sample
@@ -23,7 +23,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_embystat embystat;
         proxy_pass http://$upstream_embystat:6555;
     }

--- a/flood.subdomain.conf.sample
+++ b/flood.subdomain.conf.sample
@@ -23,7 +23,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_flood flood;
         proxy_pass http://$upstream_flood:3000;
     }

--- a/flood.subfolder.conf.sample
+++ b/flood.subfolder.conf.sample
@@ -13,7 +13,6 @@ location ^~ /flood/ {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_flood flood;
     rewrite /flood(.*) $1 break;
     proxy_pass http://$upstream_flood:3000;

--- a/freshrss.subdomain.conf.sample
+++ b/freshrss.subdomain.conf.sample
@@ -23,10 +23,9 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_freshrss freshrss;
         proxy_pass http://$upstream_freshrss;
-        
+
         proxy_redirect off;
         proxy_buffering off;
         proxy_set_header Host $host;

--- a/freshrss.subfolder.conf.sample
+++ b/freshrss.subfolder.conf.sample
@@ -14,11 +14,10 @@ location ^~ /freshrss/ {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_freshrss freshrss;
     rewrite /freshrss(.*) $1 break;
     proxy_pass http://$upstream_freshrss:80;
-    
+
     proxy_redirect off;
     proxy_buffering off;
     proxy_set_header Host $host;

--- a/gitea.subdomain.conf.sample
+++ b/gitea.subdomain.conf.sample
@@ -29,7 +29,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_gitea gitea;
         proxy_pass http://$upstream_gitea:3000;
     }

--- a/gitea.subfolder.conf.sample
+++ b/gitea.subfolder.conf.sample
@@ -10,7 +10,6 @@ location /gitea {
 
 location ^~ /gitea/ {
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_gitea gitea;
     rewrite /gitea(.*) $1 break;
     proxy_pass http://$upstream_gitea:3000;

--- a/glances.subdomain.conf.sample
+++ b/glances.subdomain.conf.sample
@@ -23,7 +23,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_glances glances;
         proxy_pass http://$upstream_glances:61208;
     }

--- a/glances.subfolder.conf.sample
+++ b/glances.subfolder.conf.sample
@@ -13,7 +13,6 @@ location ^~ /glances/ {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_glances glances;
     rewrite /glances(.*) $1 break;
     proxy_pass http://$upstream_glances:61208;

--- a/grafana.subdomain.conf.sample
+++ b/grafana.subdomain.conf.sample
@@ -23,7 +23,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_grafana grafana;
         proxy_pass http://$upstream_grafana:3000;
     }

--- a/grocy.subdomain.conf.sample
+++ b/grocy.subdomain.conf.sample
@@ -23,7 +23,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_grocy grocy;
         proxy_pass http://$upstream_grocy:80;
     }

--- a/guacamole.subdomain.conf.sample
+++ b/guacamole.subdomain.conf.sample
@@ -24,7 +24,6 @@ server {
 
         include /config/nginx/proxy.conf;
         proxy_buffering off;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_guacamole guacamole;
         proxy_pass http://$upstream_guacamole:8080;
     }

--- a/guacamole.subfolder.conf.sample
+++ b/guacamole.subfolder.conf.sample
@@ -14,7 +14,6 @@ location ^~ /guacamole/ {
 
     include /config/nginx/proxy.conf;
     proxy_buffering off;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_guacamole guacamole;
     rewrite /guacamole(.*) $1 break;
     proxy_pass http://$upstream_guacamole:8080;

--- a/headphones.subdomain.conf.sample
+++ b/headphones.subdomain.conf.sample
@@ -23,7 +23,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_headphones headphones;
         proxy_pass http://$upstream_headphones:8181;
     }

--- a/headphones.subfolder.conf.sample
+++ b/headphones.subfolder.conf.sample
@@ -10,7 +10,6 @@ location ^~ /headphones {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_headphones headphones;
     proxy_pass http://$upstream_headphones:8181;
 }

--- a/heimdall.subdomain.conf.sample
+++ b/heimdall.subdomain.conf.sample
@@ -23,7 +23,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_heimdall heimdall;
         proxy_pass https://$upstream_heimdall:443;
     }

--- a/heimdall.subfolder.conf.sample
+++ b/heimdall.subfolder.conf.sample
@@ -10,7 +10,6 @@ location / {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_heimdall heimdall;
     proxy_pass https://$upstream_heimdall:443;
 }

--- a/homeassistant.subdomain.conf.sample
+++ b/homeassistant.subdomain.conf.sample
@@ -23,13 +23,11 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_homeassistant homeassistant;
         proxy_pass http://$upstream_homeassistant:8123;
     }
 
     location /api/websocket {
-        resolver 127.0.0.11 valid=30s;
         set $upstream_homeassistant homeassistant;
         proxy_pass http://$upstream_homeassistant:8123;
         proxy_set_header Host $host;

--- a/jackett.subdomain.conf.sample
+++ b/jackett.subdomain.conf.sample
@@ -23,14 +23,12 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_jackett jackett;
         proxy_pass http://$upstream_jackett:9117;
     }
 
     location ~ (/jackett)?/(api|dl) {
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_jackett jackett;
         proxy_pass http://$upstream_jackett:9117;
     }

--- a/jackett.subfolder.conf.sample
+++ b/jackett.subfolder.conf.sample
@@ -10,14 +10,12 @@ location /jackett {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_jackett jackett;
     proxy_pass http://$upstream_jackett:9117;
 }
 
 location ~ /jackett/(api|dl) {
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_jackett jackett;
     proxy_pass http://$upstream_jackett:9117;
 }

--- a/jellyfin.subdomain.conf.sample
+++ b/jellyfin.subdomain.conf.sample
@@ -16,20 +16,18 @@ server {
 
     location / {
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_jellyfin jellyfin;
         proxy_pass http://$upstream_jellyfin:8096;
-		
+
         proxy_set_header Range $http_range;
         proxy_set_header If-Range $http_if_range;
     }
-	
+
     location ~ (/jellyfin)?/embywebsocket {
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_jellyfin jellyfin;
         proxy_pass http://$upstream_jellyfin:8096;
-		
+
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $http_connection;
    }

--- a/jellyfin.subfolder.conf.sample
+++ b/jellyfin.subfolder.conf.sample
@@ -9,11 +9,10 @@ location /jellyfin {
 }
 location ^~ /jellyfin/ {
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_jellyfin jellyfin;
     rewrite /jellyfin(.*) $1 break;
     proxy_pass http://$upstream_jellyfin:8096;
-    
+
     proxy_set_header Range $http_range;
     proxy_set_header If-Range $http_if_range;
     proxy_set_header Upgrade $http_upgrade;

--- a/kanzi.subdomain.conf.sample
+++ b/kanzi.subdomain.conf.sample
@@ -23,7 +23,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_kanzi kanzi;
         proxy_pass https://$upstream_kanzi:8000;
     }

--- a/kanzi.subfolder.conf.sample
+++ b/kanzi.subfolder.conf.sample
@@ -13,7 +13,6 @@ location ^~ /kanzi/ {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_kanzi kanzi;
     rewrite /kanzi(.*) $1 break;
     proxy_pass https://$upstream_kanzi:8000;

--- a/lazylibrarian.subdomain.conf.sample
+++ b/lazylibrarian.subdomain.conf.sample
@@ -23,7 +23,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_lazylibrarian lazylibrarian;
         proxy_pass http://$upstream_lazylibrarian:5299;
     }

--- a/lazylibrarian.subfolder.conf.sample
+++ b/lazylibrarian.subfolder.conf.sample
@@ -10,7 +10,6 @@ location ^~ /lazylibrarian {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_lazylibrarian lazylibrarian;
     proxy_pass http://$upstream_lazylibrarian:5299;
 }

--- a/lidarr.subdomain.conf.sample
+++ b/lidarr.subdomain.conf.sample
@@ -23,14 +23,12 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_lidarr lidarr;
         proxy_pass http://$upstream_lidarr:8686;
     }
 
     location ~ (/lidarr)?/api {
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_lidarr lidarr;
         proxy_pass http://$upstream_lidarr:8686;
     }

--- a/lidarr.subfolder.conf.sample
+++ b/lidarr.subfolder.conf.sample
@@ -10,14 +10,12 @@ location ^~ /lidarr {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_lidarr lidarr;
     proxy_pass http://$upstream_lidarr:8686;
 }
 
 location ^~ /lidarr/api {
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_lidarr lidarr;
     proxy_pass http://$upstream_lidarr:8686;
 }

--- a/lychee.subdomain.conf.sample
+++ b/lychee.subdomain.conf.sample
@@ -23,7 +23,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_lychee lychee;
         proxy_pass http://$upstream_lychee;
     }

--- a/medusa.subdomain.conf.sample
+++ b/medusa.subdomain.conf.sample
@@ -25,7 +25,6 @@ server {
         include /config/nginx/proxy.conf;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
-        resolver 127.0.0.11 valid=30s;
         set $upstream_medusa medusa;
         proxy_pass http://$upstream_medusa:8081;
     }

--- a/medusa.subfolder.conf.sample
+++ b/medusa.subfolder.conf.sample
@@ -12,7 +12,6 @@ location ^~ /medusa {
     include /config/nginx/proxy.conf;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";
-    resolver 127.0.0.11 valid=30s;
     set $upstream_medusa medusa;
     proxy_pass http://$upstream_medusa:8081;
 }

--- a/monitorr.subdomain.conf.sample
+++ b/monitorr.subdomain.conf.sample
@@ -23,7 +23,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_monitorr monitorr;
         proxy_pass http://$upstream_monitorr:80;
     }

--- a/monitorr.subfolder.conf.sample
+++ b/monitorr.subfolder.conf.sample
@@ -13,7 +13,6 @@ location ^~ /monitorr/ {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_monitorr monitorr;
     proxy_pass http://$upstream_monitorr:80;
 }

--- a/mstream.subdomain.conf.sample
+++ b/mstream.subdomain.conf.sample
@@ -21,9 +21,8 @@ server {
         # enable the next two lines for ldap auth
         #auth_request /auth;
         #error_page 401 =200 /login;
-        
+
 	include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_mstream mstream;
         proxy_pass http://$upstream_mstream:3000;
     }

--- a/mylar.subdomain.conf.sample
+++ b/mylar.subdomain.conf.sample
@@ -23,7 +23,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_mylar mylar;
         proxy_pass http://$upstream_mylar:8090;
     }

--- a/mylar.subfolder.conf.sample
+++ b/mylar.subfolder.conf.sample
@@ -10,7 +10,6 @@ location ^~ /mylar {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_mylar mylar;
     proxy_pass http://$upstream_mylar:8090;
 }

--- a/mytinytodo.subfolder.conf.sample
+++ b/mytinytodo.subfolder.conf.sample
@@ -15,7 +15,6 @@ location ^~ /todo/ {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_mytinytodo mytinytodo;
     proxy_pass http://$upstream_mytinytodo:80/;
 }

--- a/netdata.subdomain.conf.sample
+++ b/netdata.subdomain.conf.sample
@@ -23,7 +23,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_netdata netdata;
         proxy_pass http://$upstream_netdata:19999;
     }

--- a/netdata.subfolder.conf.sample
+++ b/netdata.subfolder.conf.sample
@@ -13,7 +13,6 @@ location ^~ /netdata/ {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_netdata netdata;
     rewrite /netdata(.*) $1 break;
     proxy_pass http://$upstream_netdata:19999;

--- a/nextcloud.subdomain.conf.sample
+++ b/nextcloud.subdomain.conf.sample
@@ -24,7 +24,6 @@ server {
 
     location / {
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_nextcloud nextcloud;
         proxy_max_temp_file_size 2048m;
         proxy_pass https://$upstream_nextcloud:443;

--- a/nextcloud.subfolder.conf.sample
+++ b/nextcloud.subfolder.conf.sample
@@ -25,11 +25,10 @@ location /nextcloud {
 
 location ^~ /nextcloud/ {
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_nextcloud nextcloud;
     rewrite /nextcloud(.*) $1 break;
     proxy_pass https://$upstream_nextcloud:443;
-    
+
     proxy_max_temp_file_size 2048m;
 
     proxy_set_header Range $http_range;
@@ -37,4 +36,4 @@ location ^~ /nextcloud/ {
     proxy_set_header Connection $http_connection;
     proxy_redirect off;
     proxy_ssl_session_reuse off;
-} 
+}

--- a/nzbget.subdomain.conf.sample
+++ b/nzbget.subdomain.conf.sample
@@ -23,28 +23,24 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_nzbget nzbget;
         proxy_pass http://$upstream_nzbget:6789;
     }
 
     location ^~ /nzbget/jsonrpc {
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_nzbget nzbget;
         proxy_pass http://$upstream_nzbget:6789;
     }
 
     location ^~ /nzbget/jsonprpc {
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_nzbget nzbget;
         proxy_pass http://$upstream_nzbget:6789;
     }
 
     location ^~ /nzbget/xmlrpc {
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_nzbget nzbget;
         proxy_pass http://$upstream_nzbget:6789;
     }

--- a/nzbget.subfolder.conf.sample
+++ b/nzbget.subfolder.conf.sample
@@ -10,28 +10,24 @@ location ^~ /nzbget {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_nzbget nzbget;
     proxy_pass http://$upstream_nzbget:6789;
 }
 
 location ^~ /nzbget/jsonrpc {
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_nzbget nzbget;
     proxy_pass http://$upstream_nzbget:6789;
 }
 
 location ^~ /nzbget/jsonprpc {
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_nzbget nzbget;
     proxy_pass http://$upstream_nzbget:6789;
 }
 
 location ^~ /nzbget/xmlrpc {
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_nzbget nzbget;
     proxy_pass http://$upstream_nzbget:6789;
 }

--- a/nzbhydra.subdomain.conf.sample
+++ b/nzbhydra.subdomain.conf.sample
@@ -23,42 +23,36 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_nzbhydra hydra2;
         proxy_pass http://$upstream_nzbhydra:5076;
     }
 
     location ~ (/nzbhydra)?/api {
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_nzbhydra hydra2;
         proxy_pass http://$upstream_nzbhydra:5076;
     }
 
     location ~ (/nzbhydra)?/getnzb {
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_nzbhydra hydra2;
         proxy_pass http://$upstream_nzbhydra:5076;
     }
 
     location ~ (/nzbhydra)?/gettorrent {
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_nzbhydra hydra2;
         proxy_pass http://$upstream_nzbhydra:5076;
     }
 
     location ~ (/nzbhydra)?/rss {
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_nzbhydra hydra2;
         proxy_pass http://$upstream_nzbhydra:5076;
     }
 
     location ~ (/nzbhydra)?/torznab/api {
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_nzbhydra hydra2;
         proxy_pass http://$upstream_nzbhydra:5076;
     }

--- a/nzbhydra.subfolder.conf.sample
+++ b/nzbhydra.subfolder.conf.sample
@@ -10,42 +10,36 @@ location ^~ /nzbhydra {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_nzbhydra hydra2;
     proxy_pass http://$upstream_nzbhydra:5076;
 }
 
 location ^~ /nzbhydra/api {
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_nzbhydra hydra2;
     proxy_pass http://$upstream_nzbhydra:5076;
 }
 
 location ^~ /nzbhydra/getnzb {
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_nzbhydra hydra2;
     proxy_pass http://$upstream_nzbhydra:5076;
 }
 
 location ^~ /nzbhydra/gettorrent {
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_nzbhydra hydra2;
     proxy_pass http://$upstream_nzbhydra:5076;
 }
 
 location ^~ /nzbhydra/rss {
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_nzbhydra hydra2;
     proxy_pass http://$upstream_nzbhydra:5076;
 }
 
 location ^~ /nzbhydra/torznab/api {
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_nzbhydra hydra2;
     proxy_pass http://$upstream_nzbhydra:5076;
 }

--- a/ombi.subdomain.conf.sample
+++ b/ombi.subdomain.conf.sample
@@ -23,7 +23,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_ombi ombi;
         proxy_pass http://$upstream_ombi:3579;
     }
@@ -31,7 +30,6 @@ server {
     # This allows access to the actual api
     location ~ (/ombi)?/api {
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_ombi ombi;
         proxy_pass http://$upstream_ombi:3579;
    }
@@ -39,7 +37,6 @@ server {
     # This allows access to the documentation for the api
     location ~ (/ombi)?/swagger {
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_ombi ombi;
         proxy_pass http://$upstream_ombi:3579;
    }

--- a/ombi.subfolder.conf.sample
+++ b/ombi.subfolder.conf.sample
@@ -14,7 +14,6 @@ location ^~ /ombi/ {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_ombi ombi;
     proxy_pass http://$upstream_ombi:3579;
 }
@@ -22,7 +21,6 @@ location ^~ /ombi/ {
 # This allows access to the actual api
 location ^~ /ombi/api {
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_ombi ombi;
     proxy_pass http://$upstream_ombi:3579;
 }
@@ -33,7 +31,6 @@ if ($http_referer ~* /ombi) {
 # This allows access to the documentation for the api
 location ^~ /ombi/swagger {
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_ombi ombi;
     proxy_pass http://$upstream_ombi:3579;
 }

--- a/organizr.subdomain.conf.sample
+++ b/organizr.subdomain.conf.sample
@@ -23,7 +23,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_organizr organizr;
         proxy_pass http://$upstream_organizr:80;
     }
@@ -32,7 +31,6 @@ server {
         # This is used for Organizr V1
         internal;
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_organizr organizr;
         proxy_pass http://$upstream_organizr:80/auth.php?$1;
         proxy_set_header Content-Length "";
@@ -42,7 +40,6 @@ server {
         # This is used for Organizr V2
         internal;
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_organizr organizr;
         proxy_pass http://$upstream_organizr:80/api/?v1/auth&group=$1;
         proxy_set_header Content-Length "";

--- a/organizr.subfolder.conf.sample
+++ b/organizr.subfolder.conf.sample
@@ -10,7 +10,6 @@ location / {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_organizr organizr;
     proxy_pass http://$upstream_organizr:80;
 }
@@ -19,7 +18,6 @@ location ~ /auth-(admin|user) {
     # This is used for Organizr V1
     internal;
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_organizr organizr;
     proxy_pass http://$upstream_organizr:80/auth.php?$1;
     proxy_set_header Content-Length "";
@@ -29,7 +27,6 @@ location ~ /auth-([0-9]+) {
     # This is used for Organizr V2
     internal;
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_organizr organizr;
     proxy_pass http://$upstream_organizr:80/api/?v1/auth&group=$1;
     proxy_set_header Content-Length "";

--- a/phpmyadmin.subdomain.conf.sample
+++ b/phpmyadmin.subdomain.conf.sample
@@ -23,7 +23,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_phpmyadmin phpmyadmin;
         proxy_pass http://$upstream_phpmyadmin:80;
     }

--- a/phpmyadmin.subfolder.conf.sample
+++ b/phpmyadmin.subfolder.conf.sample
@@ -13,7 +13,6 @@ location ^~ /phpmyadmin/ {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_phpmyadmin phpmyadmin;
     rewrite /phpmyadmin(.*) $1 break;
     proxy_pass http://$upstream_phpmyadmin:80;

--- a/pihole.subdomain.conf.sample
+++ b/pihole.subdomain.conf.sample
@@ -23,7 +23,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_pihole pihole;
         proxy_pass http://$upstream_pihole:80;
         proxy_hide_header X-Frame-Options;
@@ -39,7 +38,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_pihole pihole;
         proxy_pass http://$upstream_pihole:80;
         proxy_hide_header X-Frame-Options;

--- a/pihole.subfolder.conf.sample
+++ b/pihole.subfolder.conf.sample
@@ -13,7 +13,6 @@ location ^~ /pihole/ {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_pihole pihole;
     rewrite /pihole(.*) $1 break;
     proxy_pass http://$upstream_pihole:80;
@@ -33,7 +32,6 @@ location ^~ /pihole/admin/ {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_pihole pihole;
     rewrite /pihole(.*) $1 break;
     proxy_pass http://$upstream_pihole:80;

--- a/piwigo.subdomain.conf.sample
+++ b/piwigo.subdomain.conf.sample
@@ -23,7 +23,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_piwigo piwigo;
         proxy_pass http://$upstream_piwigo;
     }

--- a/plex.subdomain.conf.sample
+++ b/plex.subdomain.conf.sample
@@ -28,7 +28,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_plex plex;
         proxy_pass http://$upstream_plex:32400;
 

--- a/plex.subfolder.conf.sample
+++ b/plex.subfolder.conf.sample
@@ -19,7 +19,6 @@ location ^~ /plex/ {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_plex plex;
     rewrite /plex(.*) $1 break;
     proxy_pass http://$upstream_plex:32400;

--- a/plexwebtools.subdomain.conf.sample
+++ b/plexwebtools.subdomain.conf.sample
@@ -23,7 +23,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_plex plex;
         proxy_pass http://$upstream_plex:33400;
     }

--- a/plexwebtools.subfolder.conf.sample
+++ b/plexwebtools.subfolder.conf.sample
@@ -13,7 +13,6 @@ location ^~ /plexwebtools/ {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_plex plex;
     proxy_pass http://$upstream_plex:33400;
 }

--- a/portainer.subdomain.conf.sample
+++ b/portainer.subdomain.conf.sample
@@ -22,7 +22,6 @@ server {
         #auth_request /auth;
         #error_page 401 =200 /login;
 
-        resolver 127.0.0.11 valid=30s;
         set $upstream_portainer portainer;
         proxy_pass http://$upstream_portainer:9000;
         proxy_set_header Connection "";
@@ -39,7 +38,6 @@ server {
         #auth_request /auth;
         #error_page 401 =200 /login;
 
-        resolver 127.0.0.11 valid=30s;
         set $upstream_portainer portainer;
         proxy_pass http://$upstream_portainer:9000;
         proxy_set_header Upgrade $http_upgrade;

--- a/portainer.subfolder.conf.sample
+++ b/portainer.subfolder.conf.sample
@@ -13,7 +13,6 @@ location ^~ /portainer/ {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_portainer portainer;
     rewrite /portainer(.*) $1 break;
     proxy_pass http://$upstream_portainer:9000;
@@ -22,7 +21,6 @@ location ^~ /portainer/ {
 
 location ^~ /portainer/api/websocket/ {
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_portainer portainer;
     rewrite /portainer(.*) $1 break;
     proxy_pass http://$upstream_portainer:9000;

--- a/prometheus.subdomain.conf.sample
+++ b/prometheus.subdomain.conf.sample
@@ -23,7 +23,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_prometheus prometheus;
         proxy_pass http://$upstream_prometheus:9090;
     }

--- a/pydio.subdomain.conf.sample
+++ b/pydio.subdomain.conf.sample
@@ -23,7 +23,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_pydio pydio;
         proxy_pass https://$upstream_pydio:443;
     }

--- a/pyload.subdomain.conf.sample
+++ b/pyload.subdomain.conf.sample
@@ -23,7 +23,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_pyload pyload;
         proxy_pass http://$upstream_pyload:8000;
     }

--- a/qbittorrent.subdomain.conf.sample
+++ b/qbittorrent.subdomain.conf.sample
@@ -23,7 +23,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_qbittorrent qbittorrent;
         proxy_pass http://$upstream_qbittorrent:8080;
 
@@ -33,7 +32,6 @@ server {
 
     location ^~ /qbittorrent/api {
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_qbittorrent qbittorrent;
         rewrite /qbittorrent(.*) $1 break;
         proxy_pass http://$upstream_qbittorrent:8080;
@@ -44,7 +42,6 @@ server {
 
     location ^~ /qbittorrent/command {
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_qbittorrent qbittorrent;
         rewrite /qbittorrent(.*) $1 break;
         proxy_pass http://$upstream_qbittorrent:8080;
@@ -55,7 +52,6 @@ server {
 
     location ^~ /qbittorrent/query {
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_qbittorrent qbittorrent;
         rewrite /qbittorrent(.*) $1 break;
         proxy_pass http://$upstream_qbittorrent:8080;
@@ -66,7 +62,6 @@ server {
 
     location ^~ /qbittorrent/login {
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_qbittorrent qbittorrent;
         rewrite /qbittorrent(.*) $1 break;
         proxy_pass http://$upstream_qbittorrent:8080;
@@ -77,7 +72,6 @@ server {
 
     location ^~ /qbittorrent/sync {
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_qbittorrent qbittorrent;
         rewrite /qbittorrent(.*) $1 break;
         proxy_pass http://$upstream_qbittorrent:8080;

--- a/qbittorrent.subfolder.conf.sample
+++ b/qbittorrent.subfolder.conf.sample
@@ -13,7 +13,6 @@ location ^~ /qbittorrent/ {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_qbittorrent qbittorrent;
     rewrite /qbittorrent(.*) $1 break;
     proxy_pass http://$upstream_qbittorrent:8080;
@@ -24,7 +23,6 @@ location ^~ /qbittorrent/ {
 
 location ^~ /qbittorrent/api {
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_qbittorrent qbittorrent;
     rewrite /qbittorrent(.*) $1 break;
     proxy_pass http://$upstream_qbittorrent:8080;
@@ -35,7 +33,6 @@ location ^~ /qbittorrent/api {
 
 location ^~ /qbittorrent/command {
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_qbittorrent qbittorrent;
     rewrite /qbittorrent(.*) $1 break;
     proxy_pass http://$upstream_qbittorrent:8080;
@@ -46,7 +43,6 @@ location ^~ /qbittorrent/command {
 
 location ^~ /qbittorrent/query {
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_qbittorrent qbittorrent;
     rewrite /qbittorrent(.*) $1 break;
     proxy_pass http://$upstream_qbittorrent:8080;
@@ -57,7 +53,6 @@ location ^~ /qbittorrent/query {
 
 location ^~ /qbittorrent/login {
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_qbittorrent qbittorrent;
     rewrite /qbittorrent(.*) $1 break;
     proxy_pass http://$upstream_qbittorrent:8080;
@@ -68,7 +63,6 @@ location ^~ /qbittorrent/login {
 
 location ^~ /qbittorrent/sync {
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_qbittorrent qbittorrent;
     rewrite /qbittorrent(.*) $1 break;
     proxy_pass http://$upstream_qbittorrent:8080;

--- a/quassel-web.subdomain.conf.sample
+++ b/quassel-web.subdomain.conf.sample
@@ -1,4 +1,4 @@
-# make sure that your dns has a cname set for quassel and make sure Quassel-Web is running on http 
+# make sure that your dns has a cname set for quassel and make sure Quassel-Web is running on http
 # with -e 'HTTPS'='false' or if you're using -e 'ADVANCED'='true' by editing config.json appropriately
 
 server {
@@ -24,7 +24,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_quassel_web quassel-web;
         proxy_pass http://$upstream_quassel_web:64080;
     }

--- a/quassel-web.subfolder.conf.sample
+++ b/quassel-web.subfolder.conf.sample
@@ -1,4 +1,4 @@
-# Set base-url with docker run command env variable -e 'URL_BASE'='/quassel' and make sure Quassel-Web is running on http 
+# Set base-url with docker run command env variable -e 'URL_BASE'='/quassel' and make sure Quassel-Web is running on http
 # with -e 'HTTPS'='false' or if you're using -e 'ADVANCED'='true' by editing config.json appropriately
 
 location ^~ /quassel {
@@ -11,7 +11,6 @@ location ^~ /quassel {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_quassel_web quassel-web;
     proxy_pass http://$upstream_quassel_web:64080;
 }

--- a/radarr.subdomain.conf.sample
+++ b/radarr.subdomain.conf.sample
@@ -23,14 +23,12 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_radarr radarr;
         proxy_pass http://$upstream_radarr:7878;
     }
 
     location ~ (/radarr)?/api {
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_radarr radarr;
         proxy_pass http://$upstream_radarr:7878;
     }

--- a/radarr.subfolder.conf.sample
+++ b/radarr.subfolder.conf.sample
@@ -10,14 +10,12 @@ location ^~ /radarr {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_radarr radarr;
     proxy_pass http://$upstream_radarr:7878;
 }
 
 location ^~ /radarr/api {
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_radarr radarr;
     proxy_pass http://$upstream_radarr:7878;
 }

--- a/raneto.subdomain.conf.sample
+++ b/raneto.subdomain.conf.sample
@@ -22,7 +22,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_raneto raneto;
         proxy_pass http://$upstream_raneto:3000;
     }

--- a/resilio-sync.subdomain.conf.sample
+++ b/resilio-sync.subdomain.conf.sample
@@ -23,7 +23,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_resiliosync resilio-sync;
         proxy_pass http://$upstream_resiliosync:8888;
     }

--- a/rutorrent.subdomain.conf.sample
+++ b/rutorrent.subdomain.conf.sample
@@ -23,14 +23,12 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_rutorrent rutorrent;
         proxy_pass http://$upstream_rutorrent:80;
     }
 
     location /RPC2 {
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_rutorrent rutorrent;
         proxy_pass http://$upstream_rutorrent:80;
     }

--- a/rutorrent.subfolder.conf.sample
+++ b/rutorrent.subfolder.conf.sample
@@ -13,7 +13,6 @@ location ^~ /rutorrent/ {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_rutorrent rutorrent;
     rewrite /rutorrent(.*) $1 break;
     proxy_pass http://$upstream_rutorrent:80;
@@ -21,7 +20,6 @@ location ^~ /rutorrent/ {
 
 location ^~ /rutorrent/RPC2 {
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_rutorrent rutorrent;
     rewrite /rutorrent(.*) $1 break;
     proxy_pass http://$upstream_rutorrent:80;

--- a/sabnzbd.subdomain.conf.sample
+++ b/sabnzbd.subdomain.conf.sample
@@ -25,14 +25,12 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_sabnzbd sabnzbd;
         proxy_pass http://$upstream_sabnzbd:8080;
     }
 
     location ~ (/sabnzbd)?/api {
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_sabnzbd sabnzbd;
         proxy_pass http://$upstream_sabnzbd:8080;
     }

--- a/sabnzbd.subfolder.conf.sample
+++ b/sabnzbd.subfolder.conf.sample
@@ -10,14 +10,12 @@ location ^~ /sabnzbd {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_sabnzbd sabnzbd;
     proxy_pass http://$upstream_sabnzbd:8080;
 }
 
 location ^~ /sabnzbd/api {
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_sabnzbd sabnzbd;
     proxy_pass http://$upstream_sabnzbd:8080;
 }

--- a/sickrage.subdomain.conf.sample
+++ b/sickrage.subdomain.conf.sample
@@ -23,7 +23,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_sickrage sickrage;
         proxy_pass http://$upstream_sickrage:8081;
     }

--- a/sickrage.subfolder.conf.sample
+++ b/sickrage.subfolder.conf.sample
@@ -10,7 +10,6 @@ location ^~ /sickrage {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_sickrage sickrage;
     proxy_pass http://$upstream_sickrage:8081;
 }

--- a/smokeping.subdomain.conf.sample
+++ b/smokeping.subdomain.conf.sample
@@ -23,7 +23,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_smokeping smokeping;
         proxy_pass http://$upstream_smokeping;
     }

--- a/smokeping.subfolder.conf.sample
+++ b/smokeping.subfolder.conf.sample
@@ -10,7 +10,6 @@ location ^~ /smokeping {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_smokeping smokeping;
     proxy_pass http://$upstream_smokeping;
 }

--- a/sonarr.subdomain.conf.sample
+++ b/sonarr.subdomain.conf.sample
@@ -23,14 +23,12 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_sonarr sonarr;
         proxy_pass http://$upstream_sonarr:8989;
     }
 
     location ~ (/sonarr)?/api {
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_sonarr sonarr;
         proxy_pass http://$upstream_sonarr:8989;
    }

--- a/sonarr.subfolder.conf.sample
+++ b/sonarr.subfolder.conf.sample
@@ -10,14 +10,12 @@ location ^~ /sonarr {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_sonarr sonarr;
     proxy_pass http://$upstream_sonarr:8989;
 }
 
 location ^~ /sonarr/api {
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_sonarr sonarr;
     proxy_pass http://$upstream_sonarr:8989;
 }

--- a/syncthing.subdomain.conf.sample
+++ b/syncthing.subdomain.conf.sample
@@ -23,7 +23,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_syncthing syncthing;
         proxy_pass http://$upstream_syncthing:8384;
     }

--- a/taisun.subdomain.conf.sample
+++ b/taisun.subdomain.conf.sample
@@ -23,7 +23,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_taisun taisun;
         proxy_pass http://$upstream_taisun:3000;
         proxy_buffering off;

--- a/tautulli.subdomain.conf.sample
+++ b/tautulli.subdomain.conf.sample
@@ -23,14 +23,12 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_tautulli tautulli;
         proxy_pass http://$upstream_tautulli:8181;
     }
 
     location ~ (/tautulli)?/api {
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_tautulli tautulli;
         proxy_pass http://$upstream_tautulli:8181;
     }

--- a/tautulli.subfolder.conf.sample
+++ b/tautulli.subfolder.conf.sample
@@ -10,14 +10,12 @@ location ^~ /tautulli {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_tautulli tautulli;
     proxy_pass http://$upstream_tautulli:8181;
 }
 
 location ^~ /tautulli/api {
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_tautulli tautulli;
     proxy_pass http://$upstream_tautulli:8181;
 }

--- a/thelounge.subdomain.conf.sample
+++ b/thelounge.subdomain.conf.sample
@@ -23,7 +23,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_thelounge thelounge;
         proxy_pass http://$upstream_thelounge:9000;
     }

--- a/thelounge.subfolder.conf.sample
+++ b/thelounge.subfolder.conf.sample
@@ -13,7 +13,6 @@ location ^~ /thelounge/ {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_thelounge thelounge;
     rewrite /thelounge(.*) $1 break;
     proxy_pass http://$upstream_thelounge:9000;

--- a/transmission.subdomain.conf.sample
+++ b/transmission.subdomain.conf.sample
@@ -23,7 +23,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_transmission transmission;
         proxy_pass_header  X-Transmission-Session-Id;
         proxy_pass http://$upstream_transmission:9091;
@@ -31,7 +30,6 @@ server {
 
     location ~ (/transmission)?/rpc {
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_transmission transmission;
         proxy_pass http://$upstream_transmission:9091;
     }

--- a/transmission.subfolder.conf.sample
+++ b/transmission.subfolder.conf.sample
@@ -10,7 +10,6 @@ location ^~ /transmission {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_transmission transmission;
     proxy_pass_header  X-Transmission-Session-Id;
     proxy_pass http://$upstream_transmission:9091;
@@ -18,7 +17,6 @@ location ^~ /transmission {
 
 location ^~ /transmission/rpc {
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_transmission transmission;
     proxy_pass http://$upstream_transmission:9091;
 }

--- a/tt-rss.subdomain.conf.sample
+++ b/tt-rss.subdomain.conf.sample
@@ -22,8 +22,7 @@ server {
         # enable the next two lines for ldap auth
         #auth_request /auth;
         #error_page 401 =200 /login;
-        
-        resolver 127.0.0.11 valid=30s;
+
         set $upstream_tt_rss tt-rss;
         proxy_pass http://$upstream_tt_rss:80;
         proxy_redirect  http://$upstream_tt_rss:80 /;

--- a/ubooquity.subdomain.conf.sample
+++ b/ubooquity.subdomain.conf.sample
@@ -21,30 +21,26 @@ server {
         # enable the next two lines for ldap auth
         #auth_request /auth;
         #error_page 401 =200 /login;
-        
+
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_ubooquity ubooquity;
         proxy_pass http://$upstream_ubooquity:2202;
     }
 
     location /admin {
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_ubooquity ubooquity;
         proxy_pass http://$upstream_ubooquity:2203;
     }
 
     location /admin-res {
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_ubooquity ubooquity;
         proxy_pass http://$upstream_ubooquity:2203;
     }
 
     location /admin-api {
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_ubooquity ubooquity;
         proxy_pass http://$upstream_ubooquity:2203;
     }

--- a/ubooquity.subfolder.conf.sample
+++ b/ubooquity.subfolder.conf.sample
@@ -10,14 +10,12 @@
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_ubooquity ubooquity;
         proxy_pass http://$upstream_ubooquity:2202;
     }
 
     location ^~ /ubooquity/admin {
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_ubooquity ubooquity;
         proxy_pass http://$upstream_ubooquity:2203;
     }

--- a/unifi-controller.subdomain.conf.sample
+++ b/unifi-controller.subdomain.conf.sample
@@ -23,7 +23,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_unifi unifi-controller;
         proxy_pass https://$upstream_unifi:8443;
     }
@@ -38,7 +37,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_unifi unifi-controller;
         proxy_pass https://$upstream_unifi:8443;
         proxy_buffering off;

--- a/znc.subdomain.conf.sample
+++ b/znc.subdomain.conf.sample
@@ -23,7 +23,6 @@ server {
         #error_page 401 =200 /login;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
         set $upstream_znc znc;
         proxy_pass http://$upstream_znc:6501;
     }

--- a/znc.subfolder.conf.sample
+++ b/znc.subfolder.conf.sample
@@ -10,7 +10,6 @@ location /znc {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
     set $upstream_znc znc;
     proxy_pass http://$upstream_znc:6501;
 }


### PR DESCRIPTION
Follow up to https://github.com/linuxserver/docker-letsencrypt/pull/317

Since `resolver 127.0.0.11 valid=30s;` was added to `ssl.conf` it was brought to my attention that it is redundant to be in all of the proxy configs.

There's also a few whitespace and EOL changes in here (blame vscode, I got tired of trying to stop it).