### PR TITLE
Fix Airsonic subdomain webUI http request on 443

### DIFF
--- a/airsonic.subdomain.conf.sample
+++ b/airsonic.subdomain.conf.sample
@@ -25,6 +25,7 @@ server {
         include /config/nginx/proxy.conf;
         resolver 127.0.0.11 valid=30s;
         set $upstream_airsonic airsonic;
+        proxy_set_header X-Forwarded-Host  $http_host;
         proxy_pass http://$upstream_airsonic:4040;
     }
 }


### PR DESCRIPTION
Issue:  Fixes #105 
When streaming via the webui on https://airsonic.myaddress.com opening a stream generates a url that looks like http://airsonic.myaddress.com:443/stream?player=5&id=176
Which nginx sees as a bad request as it's a http request on port 443.  

Adding `proxy_set_header X-Forwarded-Host  $http_host;` fixes this issue.

[Note the Airsonic docs list X-Forwarded-Host as a required parameter when running it behind a reverse proxy](https://airsonic.github.io/docs/proxy/prerequisites/)
	



