### PR TITLE
nginx threw up error, fixed websocket

### DIFF
--- a/jellyfin.subdomain.conf.sample
+++ b/jellyfin.subdomain.conf.sample
@@ -24,7 +24,7 @@ server {
         proxy_set_header If-Range $http_if_range;
     }
 	
-    location ~ (/jellyfin)?/embywebsocket {
+    location ~ (/jellyfin)?/socket {
         include /config/nginx/proxy.conf;
         resolver 127.0.0.11 valid=30s;
         set $upstream_jellyfin jellyfin;


### PR DESCRIPTION
Changed from /embywebsocket to /socket
https://jellyfin.org/docs/general/administration/reverse-proxy.html

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

