### PR TITLE
removed redundant resolver line

### DIFF
--- a/collabora.subdomain.conf.sample
+++ b/collabora.subdomain.conf.sample
@@ -8,7 +8,6 @@ server {
 
     include /config/nginx/ssl.conf;
 
-    resolver 127.0.0.11 valid=30s;
     set $upstream_collabora collabora;
 
     # static files

--- a/collabora.subdomain.conf.sample
+++ b/collabora.subdomain.conf.sample
@@ -8,28 +8,34 @@ server {
 
     include /config/nginx/ssl.conf;
 
-    set $upstream_collabora collabora;
-
     # static files
     location ^~ /loleaflet {
+        resolver 127.0.0.11 valid=30s;
+        set $upstream_collabora collabora;
         proxy_pass https://$upstream_collabora:9980;
         proxy_set_header Host $http_host;
     }
 
     # WOPI discovery URL
     location ^~ /hosting/discovery {
+        resolver 127.0.0.11 valid=30s;
+        set $upstream_collabora collabora;
         proxy_pass https://$upstream_collabora:9980;
         proxy_set_header Host $http_host;
     }
 
     # Capabilities
     location ^~ /hosting/capabilities {
+        resolver 127.0.0.11 valid=30s;
+        set $upstream_collabora collabora;
         proxy_pass https://$upstream_collabora:9980;
         proxy_set_header Host $http_host;
     }
 
     # main websocket
     location ~ ^/lool/(.*)/ws$ {
+        resolver 127.0.0.11 valid=30s;
+        set $upstream_collabora collabora;
         proxy_pass https://$upstream_collabora:9980;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
@@ -39,12 +45,16 @@ server {
 
     # download, presentation and image upload
     location ~ ^/lool {
+        resolver 127.0.0.11 valid=30s;
+        set $upstream_collabora collabora;
         proxy_pass https://$upstream_collabora:9980;
         proxy_set_header Host $http_host;
     }
 
     # Admin Console websocket
     location ^~ /lool/adminws {
+        resolver 127.0.0.11 valid=30s;
+        set $upstream_collabora collabora;
         proxy_pass https://$upstream_collabora:9980;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";


### PR DESCRIPTION
removed redundant resolver 127.0.0.11 valid=30s; from server block. It's already in ssl.conf which is included via line 9

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

