### PR TITLE
NZBGet URL Credentials

### DIFF
--- a/nzbget.subdomain.conf.sample
+++ b/nzbget.subdomain.conf.sample
@@ -28,21 +28,21 @@ server {
         proxy_pass http://$upstream_nzbget:6789;
     }
 
-    location ~ ^/nzbget(/.*)?/jsonrpc {
+    location ~ (/nzbget)?(/[^\/:]*:[^\/:]*)?/jsonrpc {
         include /config/nginx/proxy.conf;
         resolver 127.0.0.11 valid=30s;
         set $upstream_nzbget nzbget;
         proxy_pass http://$upstream_nzbget:6789;
     }
 
-    location ~ ^/nzbget(/.*)?/jsonprpc {
+    location ~ (/nzbget)?(/[^\/:]*:[^\/:]*)?/jsonprpc {
         include /config/nginx/proxy.conf;
         resolver 127.0.0.11 valid=30s;
         set $upstream_nzbget nzbget;
         proxy_pass http://$upstream_nzbget:6789;
     }
 
-    location ~ ^/nzbget(/.*)?/xmlrpc {
+    location ~ (/nzbget)?(/[^\/:]*:[^\/:]*)?/xmlrpc {
         include /config/nginx/proxy.conf;
         resolver 127.0.0.11 valid=30s;
         set $upstream_nzbget nzbget;

--- a/nzbget.subdomain.conf.sample
+++ b/nzbget.subdomain.conf.sample
@@ -28,21 +28,21 @@ server {
         proxy_pass http://$upstream_nzbget:6789;
     }
 
-    location ^~ /nzbget/jsonrpc {
+    location ~ ^/nzbget(/.*)?/jsonrpc {
         include /config/nginx/proxy.conf;
         resolver 127.0.0.11 valid=30s;
         set $upstream_nzbget nzbget;
         proxy_pass http://$upstream_nzbget:6789;
     }
 
-    location ^~ /nzbget/jsonprpc {
+    location ~ ^/nzbget(/.*)?/jsonprpc {
         include /config/nginx/proxy.conf;
         resolver 127.0.0.11 valid=30s;
         set $upstream_nzbget nzbget;
         proxy_pass http://$upstream_nzbget:6789;
     }
 
-    location ^~ /nzbget/xmlrpc {
+    location ~ ^/nzbget(/.*)?/xmlrpc {
         include /config/nginx/proxy.conf;
         resolver 127.0.0.11 valid=30s;
         set $upstream_nzbget nzbget;

--- a/nzbget.subdomain.conf.sample
+++ b/nzbget.subdomain.conf.sample
@@ -35,14 +35,14 @@ server {
         proxy_pass http://$upstream_nzbget:6789;
     }
 
-    location ~ (/nzbget)?(/[^\/:]*:[^\/:]*)?/jsonprpc {
+    location ~ (/nzbget)?(/[^\/:]*:[^\/]*)?/jsonprpc {
         include /config/nginx/proxy.conf;
         resolver 127.0.0.11 valid=30s;
         set $upstream_nzbget nzbget;
         proxy_pass http://$upstream_nzbget:6789;
     }
 
-    location ~ (/nzbget)?(/[^\/:]*:[^\/:]*)?/xmlrpc {
+    location ~ (/nzbget)?(/[^\/:]*:[^\/]*)?/xmlrpc {
         include /config/nginx/proxy.conf;
         resolver 127.0.0.11 valid=30s;
         set $upstream_nzbget nzbget;

--- a/nzbget.subfolder.conf.sample
+++ b/nzbget.subfolder.conf.sample
@@ -15,21 +15,21 @@ location /nzbget {
     proxy_pass http://$upstream_nzbget:6789;
 }
 
-location ~ ^/nzbget(/.*)?/jsonrpc {
+location ~ /nzbget(/[^\/:]*:[^\/:]*)?/jsonrpc {
     include /config/nginx/proxy.conf;
     resolver 127.0.0.11 valid=30s;
     set $upstream_nzbget nzbget;
     proxy_pass http://$upstream_nzbget:6789;
 }
 
-location ~ ^/nzbget(/.*)?/jsonprpc {
+location ~ /nzbget(/[^\/:]*:[^\/:]*)?/jsonprpc {
     include /config/nginx/proxy.conf;
     resolver 127.0.0.11 valid=30s;
     set $upstream_nzbget nzbget;
     proxy_pass http://$upstream_nzbget:6789;
 }
 
-location ~ ^/nzbget(/.*)?/xmlrpc {
+location ~ /nzbget(/[^\/:]*:[^\/:]*)?/xmlrpc {
     include /config/nginx/proxy.conf;
     resolver 127.0.0.11 valid=30s;
     set $upstream_nzbget nzbget;

--- a/nzbget.subfolder.conf.sample
+++ b/nzbget.subfolder.conf.sample
@@ -15,21 +15,21 @@ location /nzbget {
     proxy_pass http://$upstream_nzbget:6789;
 }
 
-location ~ /nzbget(/[^\/:]*:[^\/:]*)?/jsonrpc {
+location ~ /nzbget(/[^\/:]*:[^\/]*)?/jsonrpc {
     include /config/nginx/proxy.conf;
     resolver 127.0.0.11 valid=30s;
     set $upstream_nzbget nzbget;
     proxy_pass http://$upstream_nzbget:6789;
 }
 
-location ~ /nzbget(/[^\/:]*:[^\/:]*)?/jsonprpc {
+location ~ /nzbget(/[^\/:]*:[^\/]*)?/jsonprpc {
     include /config/nginx/proxy.conf;
     resolver 127.0.0.11 valid=30s;
     set $upstream_nzbget nzbget;
     proxy_pass http://$upstream_nzbget:6789;
 }
 
-location ~ /nzbget(/[^\/:]*:[^\/:]*)?/xmlrpc {
+location ~ /nzbget(/[^\/:]*:[^\/]*)?/xmlrpc {
     include /config/nginx/proxy.conf;
     resolver 127.0.0.11 valid=30s;
     set $upstream_nzbget nzbget;

--- a/nzbget.subfolder.conf.sample
+++ b/nzbget.subfolder.conf.sample
@@ -1,6 +1,6 @@
 # nzbget does not require a base url setting
 
-location ^~ /nzbget {
+location /nzbget {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
@@ -15,21 +15,21 @@ location ^~ /nzbget {
     proxy_pass http://$upstream_nzbget:6789;
 }
 
-location ^~ /nzbget/jsonrpc {
+location ~ ^/nzbget(/.*)?/jsonrpc {
     include /config/nginx/proxy.conf;
     resolver 127.0.0.11 valid=30s;
     set $upstream_nzbget nzbget;
     proxy_pass http://$upstream_nzbget:6789;
 }
 
-location ^~ /nzbget/jsonprpc {
+location ~ ^/nzbget(/.*)?/jsonprpc {
     include /config/nginx/proxy.conf;
     resolver 127.0.0.11 valid=30s;
     set $upstream_nzbget nzbget;
     proxy_pass http://$upstream_nzbget:6789;
 }
 
-location ^~ /nzbget/xmlrpc {
+location ~ ^/nzbget(/.*)?/xmlrpc {
     include /config/nginx/proxy.conf;
     resolver 127.0.0.11 valid=30s;
     set $upstream_nzbget nzbget;


### PR DESCRIPTION
This allows the NZBGet credentials to be passed through the URL since LunaSea changed to using this method for auth instead of headers.

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

