### PR TITLE
Update organizr.subfolder.conf.sample

### DIFF
--- a/organizr.subfolder.conf.sample
+++ b/organizr.subfolder.conf.sample
@@ -1,6 +1,6 @@
 # In order to use this location block you need to edit the default file one folder up and comment out the / location
 
-location / {
+location /organizr {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;


### PR DESCRIPTION
location clause was "/" causing errors. Changed to "/organizr"

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

