### PR TITLE
Fix for 404 and PHP errors

### DIFF
--- a/organizr.subfolder.conf.sample
+++ b/organizr.subfolder.conf.sample
@@ -10,12 +10,13 @@ location ^~ / {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
-    proxy_intercept_errors on;
     resolver 127.0.0.11 valid=30s;
     set $upstream_app organizr;
     set $upstream_port 80;
     set $upstream_proto http;
     proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    proxy_intercept_errors on;
 
 }
 

--- a/organizr.subfolder.conf.sample
+++ b/organizr.subfolder.conf.sample
@@ -1,6 +1,6 @@
 # In order to use this location block you need to edit the default file one folder up and comment out the / location
 
-location / {
+location ^~ / {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
@@ -10,6 +10,7 @@ location / {
     #error_page 401 =200 /login;
 
     include /config/nginx/proxy.conf;
+    proxy_intercept_errors on;
     resolver 127.0.0.11 valid=30s;
     set $upstream_app organizr;
     set $upstream_port 80;


### PR DESCRIPTION
The `^~` prevents Organizr's PHP from getting filtered through container's PHP and the `proxy_intercept_errors` allows the 404 to work (since the 404 is actually being thrown by the proxy)

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

