### PR TITLE
Added Gotify Subdomain Config

### DIFF
--- a/gotify.subdomain.conf.sample
+++ b/gotify.subdomain.conf.sample
@@ -1,0 +1,32 @@
+# make sure that your dns has a cname set for gotify
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name gotify.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    # enable for ldap auth, fill in ldap details in ldap.conf
+    #include /config/nginx/ldap.conf;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable the next two lines for ldap auth
+        #auth_request /auth;
+        #error_page 401 =200 /login;
+
+        include /config/nginx/proxy.conf;
+        resolver 127.0.0.11 valid=30s;
+        set $upstream_gotify gotify;
+        proxy_pass http://$upstream_gotify;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+}

--- a/gotify.subdomain.conf.sample
+++ b/gotify.subdomain.conf.sample
@@ -24,8 +24,10 @@ server {
 
         include /config/nginx/proxy.conf;
         resolver 127.0.0.11 valid=30s;
-        set $upstream_gotify gotify;
-        proxy_pass http://$upstream_gotify;
+        set $upstream_app gotify;
+        set $upstream_port 80;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
     }


### PR DESCRIPTION
Adds a subdomain proxy config for Gotify, a simple server for sending and receiving messages.

Includes websocket proxying for web UI.