### PR TITLE
qbittorrent use $upstream_port in proxy_set_header

### DIFF
--- a/qbittorrent.subdomain.conf.sample
+++ b/qbittorrent.subdomain.conf.sample
@@ -30,7 +30,7 @@ server {
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
         proxy_set_header Referer '';
-        proxy_set_header Host $upstream_app:8080;
+        proxy_set_header Host $upstream_app:$upstream_port;
     }
 
     location ~ (/qbittorrent)?/api {
@@ -44,7 +44,7 @@ server {
         rewrite /qbittorrent(.*) $1 break;
 
         proxy_set_header Referer '';
-        proxy_set_header Host $upstream_app:8080;
+        proxy_set_header Host $upstream_app:$upstream_port;
     }
 
     location ~ (/qbittorrent)?/command {
@@ -58,7 +58,7 @@ server {
         rewrite /qbittorrent(.*) $1 break;
 
         proxy_set_header Referer '';
-        proxy_set_header Host $upstream_app:8080;
+        proxy_set_header Host $upstream_app:$upstream_port;
     }
 
     location ~ (/qbittorrent)?/query {
@@ -72,7 +72,7 @@ server {
         rewrite /qbittorrent(.*) $1 break;
 
         proxy_set_header Referer '';
-        proxy_set_header Host $upstream_app:8080;
+        proxy_set_header Host $upstream_app:$upstream_port;
     }
 
     location ~ (/qbittorrent)?/login {
@@ -86,7 +86,7 @@ server {
         rewrite /qbittorrent(.*) $1 break;
 
         proxy_set_header Referer '';
-        proxy_set_header Host $upstream_app:8080;
+        proxy_set_header Host $upstream_app:$upstream_port;
     }
 
     location ~ (/qbittorrent)?/sync {
@@ -100,6 +100,6 @@ server {
         rewrite /qbittorrent(.*) $1 break;
 
         proxy_set_header Referer '';
-        proxy_set_header Host $upstream_app:8080;
+        proxy_set_header Host $upstream_app:$upstream_port;
     }
 }

--- a/qbittorrent.subfolder.conf.sample
+++ b/qbittorrent.subfolder.conf.sample
@@ -22,7 +22,7 @@ location ^~ /qbittorrent/ {
     rewrite /qbittorrent(.*) $1 break;
 
     proxy_set_header Referer '';
-    proxy_set_header Host $upstream_app:8080;
+    proxy_set_header Host $upstream_app:$upstream_port;
 }
 
 location ^~ /qbittorrent/api {
@@ -36,7 +36,7 @@ location ^~ /qbittorrent/api {
     rewrite /qbittorrent(.*) $1 break;
 
     proxy_set_header Referer '';
-    proxy_set_header Host $upstream_app:8080;
+    proxy_set_header Host $upstream_app:$upstream_port;
 }
 
 location ^~ /qbittorrent/command {
@@ -50,7 +50,7 @@ location ^~ /qbittorrent/command {
     rewrite /qbittorrent(.*) $1 break;
 
     proxy_set_header Referer '';
-    proxy_set_header Host $upstream_app:8080;
+    proxy_set_header Host $upstream_app:$upstream_port;
 }
 
 location ^~ /qbittorrent/query {
@@ -64,7 +64,7 @@ location ^~ /qbittorrent/query {
     rewrite /qbittorrent(.*) $1 break;
 
     proxy_set_header Referer '';
-    proxy_set_header Host $upstream_app:8080;
+    proxy_set_header Host $upstream_app:$upstream_port;
 }
 
 location ^~ /qbittorrent/login {
@@ -78,7 +78,7 @@ location ^~ /qbittorrent/login {
     rewrite /qbittorrent(.*) $1 break;
 
     proxy_set_header Referer '';
-    proxy_set_header Host $upstream_app:8080;
+    proxy_set_header Host $upstream_app:$upstream_port;
 }
 
 location ^~ /qbittorrent/sync {
@@ -92,5 +92,5 @@ location ^~ /qbittorrent/sync {
     rewrite /qbittorrent(.*) $1 break;
 
     proxy_set_header Referer '';
-    proxy_set_header Host $upstream_app:8080;
+    proxy_set_header Host $upstream_app:$upstream_port;
 }


### PR DESCRIPTION
Small change to use `$upstream_port` for `proxy_set_header` as it was previously hard-coded instead of using the defined value already being used for `proxy_pass`