### PR TITLE
Radarr headers

### DIFF
--- a/radarr.subdomain.conf.sample
+++ b/radarr.subdomain.conf.sample
@@ -29,6 +29,8 @@ server {
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $http_connection;
     }
 
     location ~ (/radarr)?/api {
@@ -39,5 +41,7 @@ server {
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $http_connection;
     }
 }

--- a/radarr.subfolder.conf.sample
+++ b/radarr.subfolder.conf.sample
@@ -16,6 +16,8 @@ location ^~ /radarr {
     set $upstream_proto http;
     proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $http_connection;
 }
 
 location ^~ /radarr/api {
@@ -26,4 +28,6 @@ location ^~ /radarr/api {
     set $upstream_proto http;
     proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $http_connection;
 }


### PR DESCRIPTION
Resolves https://github.com/Radarr/Radarr/wiki/Health-Checks#could-not-connect-to-signalr

We already have `proxy_http_version 1.1;` in proxy.conf