### PR TITLE
include proxy.conf in portainer subdomain config

### DIFF
--- a/portainer.subdomain.conf.sample
+++ b/portainer.subdomain.conf.sample
@@ -28,6 +28,7 @@ server {
         # enable for Authelia
         #include /config/nginx/authelia-location.conf;
 
+        include /config/nginx/proxy.conf;
         resolver 127.0.0.11 valid=30s;
         set $upstream_app portainer;
         set $upstream_port 9000;
@@ -35,7 +36,6 @@ server {
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
         proxy_set_header Connection "";
-        proxy_http_version 1.1;
         proxy_hide_header X-Frame-Options; # Possibly nott needed after Portainer 1.20.0
     }
 
@@ -51,6 +51,7 @@ server {
         # enable for Authelia
         #include /config/nginx/authelia-location.conf;
 
+        include /config/nginx/proxy.conf;
         resolver 127.0.0.11 valid=30s;
         set $upstream_app portainer;
         set $upstream_port 9000;
@@ -59,7 +60,6 @@ server {
 
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
-        proxy_http_version 1.1;
         proxy_hide_header X-Frame-Options; # Possibly nott needed after Portainer 1.20.0
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
I noticed that my general proxy config was not applied to this reverse proxy. All other ones (that I use) do have it included.

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
I wanted to raise an issue for this, but I assumed it would be easier for everyone to make a PR instead.
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->
I currently have this setup running fine.

##  Thanks, team linuxserver.io

