### PR TITLE
Create aspnet.subdomain.conf.sample

### DIFF
--- a/aspnet.subdomain.conf.sample
+++ b/aspnet.subdomain.conf.sample
@@ -1,0 +1,26 @@
+# aspnet reverse proxy configuration for https to http on duckdns subdomain
+# replace <subdomain> w/ duckdns subdomain & <container> w/ http service name
+# add environment variable ASPNETCORE_FORWARDEDHEADERS_ENABLED: "true" in docker
+
+server {
+    listen 443 ssl http2 default_server;
+    server_name _;
+    include /config/nginx/ssl.conf;
+    return 301 https://www.$host$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name *.<subdomain>.duckdns.org;
+    include /config/nginx/ssl.conf;
+    location / {
+        proxy_pass http://<container>;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $http_connection;
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
Adds a template for ASP.NET Core website exposing http port to be be proxied as https with a Duck DNS subdomain.  Hopefully this can help someone else trying to get a secure website up and running via nginx reverse proxy and letsencrypt certificate.