### PR TITLE
Cleanup redundant headers from proxy.conf

### DIFF
--- a/adguard.subdomain.conf.sample
+++ b/adguard.subdomain.conf.sample
@@ -44,6 +44,6 @@ server {
         set $upstream_port 80;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
-        
+
     }
 }

--- a/adminer.subfolder.conf.sample
+++ b/adminer.subfolder.conf.sample
@@ -3,6 +3,7 @@
 location /adminer {
     return 301 $scheme://$host/adminer/;
 }
+
 location ^~ /adminer/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";

--- a/bazarr.subdomain.conf.sample
+++ b/bazarr.subdomain.conf.sample
@@ -35,8 +35,6 @@ server {
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "Upgrade";
     }
 
     location ~ (/bazarr)?/api {
@@ -47,7 +45,5 @@ server {
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "Upgrade";
     }
 }

--- a/bazarr.subfolder.conf.sample
+++ b/bazarr.subfolder.conf.sample
@@ -3,6 +3,7 @@
 location /bazarr {
     return 301 $scheme://$host/bazarr/;
 }
+
 location ^~ /bazarr/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
@@ -22,8 +23,6 @@ location ^~ /bazarr/ {
     set $upstream_proto http;
     proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection "Upgrade";
 }
 
 location ^~ /bazarr/api {
@@ -34,6 +33,4 @@ location ^~ /bazarr/api {
     set $upstream_proto http;
     proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection "Upgrade";
 }

--- a/beets.subfolder.conf.sample
+++ b/beets.subfolder.conf.sample
@@ -19,8 +19,6 @@ location /beets {
     set $upstream_proto http;
     proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
-    proxy_set_header Host $host;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Scheme $scheme;
     proxy_set_header X-Script-Name /beets;
 }

--- a/bitwarden.subdomain.conf.sample
+++ b/bitwarden.subdomain.conf.sample
@@ -1,5 +1,6 @@
 # make sure that your dns has a cname set for bitwarden and that your bitwarden container is not using a base url
 # make sure your bitwarden container is named "bitwarden"
+# set the environment variable WEBSOCKET_ENABLED=true on your bitwarden container
 
 server {
     listen 443 ssl;
@@ -38,7 +39,18 @@ server {
 
     }
 
-    location /notifications/hub {
+    location /admin {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable the next two lines for ldap auth
+        #auth_request /auth;
+        #error_page 401 =200 /ldaplogin;
+
+        # enable for Authelia
+        #include /config/nginx/authelia-location.conf;
+
         include /config/nginx/proxy.conf;
         resolver 127.0.0.11 valid=30s;
         set $upstream_app bitwarden;
@@ -46,8 +58,16 @@ server {
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "Upgrade";
+    }
+
+    location /notifications/hub {
+        include /config/nginx/proxy.conf;
+        resolver 127.0.0.11 valid=30s;
+        set $upstream_app bitwarden;
+        set $upstream_port 3012;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
     }
 
     location /notifications/hub/negotiate {
@@ -59,5 +79,4 @@ server {
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
     }
-
 }

--- a/bookstack.subdomain.conf.sample
+++ b/bookstack.subdomain.conf.sample
@@ -37,5 +37,5 @@ server {
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
-    }   
+    }
 }

--- a/calibre-web.subfolder.conf.sample
+++ b/calibre-web.subfolder.conf.sample
@@ -3,6 +3,7 @@
 location /calibre-web {
     return 301 $scheme://$host/calibre-web/;
 }
+
 location ^~ /calibre-web/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";

--- a/calibre.subdomain.conf.sample
+++ b/calibre.subdomain.conf.sample
@@ -35,7 +35,5 @@ server {
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
         proxy_buffering off;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection $http_connection;
     }
 }

--- a/calibre.subfolder.conf.sample
+++ b/calibre.subfolder.conf.sample
@@ -3,6 +3,7 @@
 location /calibre {
     return 301 $scheme://$host/calibre/;
 }
+
 location ^~ /calibre/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";

--- a/code-server.subdomain.conf.sample
+++ b/code-server.subdomain.conf.sample
@@ -35,7 +35,5 @@ server {
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection upgrade;
     }
 }

--- a/collabora.subdomain.conf.sample
+++ b/collabora.subdomain.conf.sample
@@ -49,8 +49,6 @@ server {
         set $upstream_proto https;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "Upgrade";
         proxy_set_header Host $http_host;
         proxy_read_timeout 36000s;
     }
@@ -74,8 +72,6 @@ server {
         set $upstream_proto https;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "Upgrade";
         proxy_set_header Host $http_host;
         proxy_read_timeout 36000s;
     }

--- a/deluge.subfolder.conf.sample
+++ b/deluge.subfolder.conf.sample
@@ -3,6 +3,7 @@
 location /deluge {
     return 301 $scheme://$host/deluge/;
 }
+
 location ^~ /deluge/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";

--- a/documentserver.subdomain.conf.sample
+++ b/documentserver.subdomain.conf.sample
@@ -35,9 +35,6 @@ server {
         set $upstream_port 80;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
-        
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection upgrade;
 
     }
 }

--- a/dozzle.subfolder.conf.sample
+++ b/dozzle.subfolder.conf.sample
@@ -3,6 +3,7 @@
 location /dozzle {
     return 301 $scheme://$host/dozzle/;
 }
+
 location ^~ /dozzle/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";

--- a/duplicati.subfolder.conf.sample
+++ b/duplicati.subfolder.conf.sample
@@ -3,6 +3,7 @@
 location /duplicati {
     return 301 $scheme://$host/duplicati/;
 }
+
 location ^~ /duplicati/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";

--- a/emby.subdomain.conf.sample
+++ b/emby.subdomain.conf.sample
@@ -25,8 +25,5 @@ server {
 
         proxy_set_header Range $http_range;
         proxy_set_header If-Range $http_if_range;
-
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection $http_connection;
-   }
+    }
 }

--- a/emby.subfolder.conf.sample
+++ b/emby.subfolder.conf.sample
@@ -8,6 +8,7 @@
 location /emby {
     return 301 $scheme://$host/emby/;
 }
+
 location ^~ /emby/ {
     include /config/nginx/proxy.conf;
     resolver 127.0.0.11 valid=30s;
@@ -28,6 +29,4 @@ location ^~ /embywebsocket {
     set $upstream_proto http;
     proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection $http_connection;
 }

--- a/flood.subfolder.conf.sample
+++ b/flood.subfolder.conf.sample
@@ -3,6 +3,7 @@
 location /flood {
     return 301 $scheme://$host/flood/;
 }
+
 location ^~ /flood/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";

--- a/glances.subfolder.conf.sample
+++ b/glances.subfolder.conf.sample
@@ -3,6 +3,7 @@
 location /glances {
     return 301 $scheme://$host/glances/;
 }
+
 location ^~ /glances/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";

--- a/gotify.subdomain.conf.sample
+++ b/gotify.subdomain.conf.sample
@@ -34,7 +34,6 @@ server {
         set $upstream_port 80;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
+
     }
 }

--- a/grocy.subdomain.conf.sample
+++ b/grocy.subdomain.conf.sample
@@ -36,5 +36,4 @@ server {
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
     }
-
 }

--- a/guacamole.subfolder.conf.sample
+++ b/guacamole.subfolder.conf.sample
@@ -3,6 +3,7 @@
 location /guacamole {
     return 301 $scheme://$host/guacamole/;
 }
+
 location ^~ /guacamole/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";

--- a/homeassistant.subdomain.conf.sample
+++ b/homeassistant.subdomain.conf.sample
@@ -36,13 +36,4 @@ server {
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
     }
-
-    location /api/websocket {
-        resolver 127.0.0.11 valid=30s;
-        set $upstream_app homeassistant;
-        set $upstream_port 8123;
-        set $upstream_proto http;
-        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
-
-    }
 }

--- a/homeassistant.subdomain.conf.sample
+++ b/homeassistant.subdomain.conf.sample
@@ -44,10 +44,5 @@ server {
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
-        proxy_set_header Host $host;
-
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
     }
 }

--- a/jellyfin.subdomain.conf.sample
+++ b/jellyfin.subdomain.conf.sample
@@ -35,7 +35,5 @@ server {
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection $http_connection;
-   }
+    }
 }

--- a/jellyfin.subfolder.conf.sample
+++ b/jellyfin.subfolder.conf.sample
@@ -8,6 +8,7 @@
 location /jellyfin {
     return 301 $scheme://$host/jellyfin/;
 }
+
 location ^~ /jellyfin/ {
     include /config/nginx/proxy.conf;
     resolver 127.0.0.11 valid=30s;
@@ -18,6 +19,4 @@ location ^~ /jellyfin/ {
 
     proxy_set_header Range $http_range;
     proxy_set_header If-Range $http_if_range;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection $http_connection;
 }

--- a/jenkins.subfolder.conf.sample
+++ b/jenkins.subfolder.conf.sample
@@ -4,6 +4,7 @@
 location /jenkins {
     return 301 $scheme://$host/jenkins/;
 }
+
 location ^~ /jenkins/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";

--- a/kanzi.subfolder.conf.sample
+++ b/kanzi.subfolder.conf.sample
@@ -3,6 +3,7 @@
 location /kanzi {
     return 301 $scheme://$host/kanzi/;
 }
+
 location ^~ /kanzi/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";

--- a/mailu.subfolder.conf.sample
+++ b/mailu.subfolder.conf.sample
@@ -6,6 +6,7 @@
 location /admin{
     return 301 $scheme://$host/admin/;
 }
+
 location ^~ /admin/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
@@ -17,7 +18,7 @@ location ^~ /admin/ {
 
     # enable for Authelia, also enable authelia-server.conf in the default site config
     #include /config/nginx/authelia-location.conf;
-    
+
     include /config/nginx/proxy.conf;
     resolver 127.0.0.11 valid=30s;
     set $upstream_app front;
@@ -30,6 +31,7 @@ location ^~ /admin/ {
 location /webmail{
     return 301 $scheme://$host/webmail/;
 }
+
 location ^~ /webmail/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
@@ -41,7 +43,7 @@ location ^~ /webmail/ {
 
     # enable for Authelia, also enable authelia-server.conf in the default site config
     #include /config/nginx/authelia-location.conf;
-    
+
     include /config/nginx/proxy.conf;
     resolver 127.0.0.11 valid=30s;
     set $upstream_app front;

--- a/medusa.subdomain.conf.sample
+++ b/medusa.subdomain.conf.sample
@@ -29,8 +29,6 @@ server {
         #include /config/nginx/authelia-location.conf;
 
         include /config/nginx/proxy.conf;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
         resolver 127.0.0.11 valid=30s;
         set $upstream_app medusa;
         set $upstream_port 8081;

--- a/medusa.subfolder.conf.sample
+++ b/medusa.subfolder.conf.sample
@@ -13,8 +13,6 @@ location ^~ /medusa {
     #include /config/nginx/authelia-location.conf;
 
     include /config/nginx/proxy.conf;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection "upgrade";
     resolver 127.0.0.11 valid=30s;
     set $upstream_app medusa;
     set $upstream_port 8081;

--- a/monitorr.subfolder.conf.sample
+++ b/monitorr.subfolder.conf.sample
@@ -3,6 +3,7 @@
 location /monitorr {
     return 301 $scheme://$host/monitorr/;
 }
+
 location ^~ /monitorr/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";

--- a/mytinytodo.subfolder.conf.sample
+++ b/mytinytodo.subfolder.conf.sample
@@ -4,6 +4,7 @@
 location /todo {
     return 301 $scheme://$host/todo/;
 }
+
 location ^~ /todo/ {
 
     # enable the next two lines for http auth

--- a/netboot.subdomain.conf.sample
+++ b/netboot.subdomain.conf.sample
@@ -34,5 +34,6 @@ server {
         set $upstream_port 3000;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
     }
 }

--- a/netdata.subfolder.conf.sample
+++ b/netdata.subfolder.conf.sample
@@ -3,6 +3,7 @@
 location /netdata {
     return 301 $scheme://$host/netdata/;
 }
+
 location ^~ /netdata/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";

--- a/nextcloud.subfolder.conf.sample
+++ b/nextcloud.subfolder.conf.sample
@@ -36,7 +36,6 @@ location ^~ /nextcloud/ {
 
     proxy_set_header Range $http_range;
     proxy_set_header If-Range $http_if_range;
-    proxy_set_header Connection $http_connection;
-    proxy_redirect off;
+        proxy_redirect off;
     proxy_ssl_session_reuse off;
 }

--- a/nzbhydra.subdomain.conf.sample
+++ b/nzbhydra.subdomain.conf.sample
@@ -86,5 +86,4 @@ server {
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
     }
-
 }

--- a/ombi.subdomain.conf.sample
+++ b/ombi.subdomain.conf.sample
@@ -58,6 +58,7 @@ server {
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
    }
+
    if ($http_referer ~* /ombi) {
        rewrite ^/swagger/(.*) /ombi/swagger/$1? redirect;
    }

--- a/ombi.subfolder.conf.sample
+++ b/ombi.subfolder.conf.sample
@@ -35,6 +35,7 @@ location ^~ /ombi/api {
     proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
 }
+
 if ($http_referer ~* /ombi) {
     rewrite ^/api/(.*) /ombi/api/$1? redirect;
 }
@@ -49,6 +50,7 @@ location ^~ /ombi/swagger {
     proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
 }
+
 if ($http_referer ~* /ombi) {
     rewrite ^/swagger/(.*) /ombi/swagger/$1? redirect;
 }

--- a/phpmyadmin.subfolder.conf.sample
+++ b/phpmyadmin.subfolder.conf.sample
@@ -3,6 +3,7 @@
 location /phpmyadmin {
     return 301 $scheme://$host/phpmyadmin/;
 }
+
 location ^~ /phpmyadmin/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";

--- a/pihole.subfolder.conf.sample
+++ b/pihole.subfolder.conf.sample
@@ -3,6 +3,7 @@
 location /pihole {
     return 301 $scheme://$host/pihole/;
 }
+
 location ^~ /pihole/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
@@ -29,6 +30,7 @@ location ^~ /pihole/ {
 location /pihole/admin {
     return 301 $scheme://$host/pihole/admin/;
 }
+
 location ^~ /pihole/admin/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";

--- a/plex.subdomain.conf.sample
+++ b/plex.subdomain.conf.sample
@@ -40,9 +40,6 @@ server {
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
-
         proxy_set_header X-Plex-Client-Identifier $http_x_plex_client_identifier;
         proxy_set_header X-Plex-Device $http_x_plex_device;
         proxy_set_header X-Plex-Device-Name $http_x_plex_device_name;

--- a/plex.subfolder.conf.sample
+++ b/plex.subfolder.conf.sample
@@ -9,6 +9,7 @@
 location /plex {
     return 301 $scheme://$host/plex/;
 }
+
 location ^~ /plex/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
@@ -43,6 +44,7 @@ location ^~ /plex/ {
     proxy_set_header X-Plex-Device-Vendor $http_x_plex_device_vendor;
     proxy_set_header X-Plex-Model $http_x_plex_model;
 }
+
 if ($http_referer ~* /plex) {
     rewrite ^/web/(.*) /plex/web/$1? redirect;
 }

--- a/plexwebtools.subfolder.conf.sample
+++ b/plexwebtools.subfolder.conf.sample
@@ -3,6 +3,7 @@
 location /plexwebtools {
     return 301 $scheme://$host/plexwebtools/;
 }
+
 location ^~ /plexwebtools/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";

--- a/portainer.subdomain.conf.sample
+++ b/portainer.subdomain.conf.sample
@@ -35,8 +35,7 @@ server {
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
-        proxy_set_header Connection "";
-        proxy_hide_header X-Frame-Options; # Possibly nott needed after Portainer 1.20.0
+        proxy_hide_header X-Frame-Options; # Possibly not needed after Portainer 1.20.0
     }
 
     location /api/websocket/ {
@@ -58,8 +57,6 @@ server {
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
-        proxy_hide_header X-Frame-Options; # Possibly nott needed after Portainer 1.20.0
+        proxy_hide_header X-Frame-Options; # Possibly not needed after Portainer 1.20.0
     }
 }

--- a/portainer.subfolder.conf.sample
+++ b/portainer.subfolder.conf.sample
@@ -3,6 +3,7 @@
 location /portainer {
     return 301 $scheme://$host/portainer/;
 }
+
 location ^~ /portainer/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
@@ -35,7 +36,5 @@ location ^~ /portainer/api/websocket/ {
     proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
     rewrite /portainer(.*) $1 break;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection "upgrade";
-    proxy_hide_header X-Frame-Options; # Possibly nott needed after Portainer 1.20.0
+    proxy_hide_header X-Frame-Options; # Possibly not needed after Portainer 1.20.0
 }

--- a/pydio-cells.subdomain.conf.sample
+++ b/pydio-cells.subdomain.conf.sample
@@ -34,6 +34,7 @@ server {
         set $upstream_port 8080;
         set $upstream_proto https;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
     }
 
     location /ws {
@@ -54,10 +55,7 @@ server {
         set $upstream_port 8080;
         set $upstream_proto https;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
-        
-        proxy_buffering off;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
-    }
 
+        proxy_buffering off;
+    }
 }

--- a/qbittorrent.subfolder.conf.sample
+++ b/qbittorrent.subfolder.conf.sample
@@ -3,6 +3,7 @@
 location /qbittorrent {
     return 301 $scheme://$host/qbittorrent/;
 }
+
 location ^~ /qbittorrent/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";

--- a/radarr.subdomain.conf.sample
+++ b/radarr.subdomain.conf.sample
@@ -35,8 +35,6 @@ server {
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection $http_connection;
     }
 
     location ~ (/radarr)?/api {
@@ -47,7 +45,5 @@ server {
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection $http_connection;
     }
 }

--- a/radarr.subfolder.conf.sample
+++ b/radarr.subfolder.conf.sample
@@ -19,8 +19,6 @@ location ^~ /radarr {
     set $upstream_proto http;
     proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection $http_connection;
 }
 
 location ^~ /radarr/api {
@@ -31,6 +29,4 @@ location ^~ /radarr/api {
     set $upstream_proto http;
     proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection $http_connection;
 }

--- a/rutorrent.subfolder.conf.sample
+++ b/rutorrent.subfolder.conf.sample
@@ -3,6 +3,7 @@
 location /rutorrent {
     return 301 $scheme://$host/rutorrent/;
 }
+
 location ^~ /rutorrent/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";

--- a/scope.subfolder.conf.sample
+++ b/scope.subfolder.conf.sample
@@ -3,6 +3,7 @@
 location /scope {
     return 301 $scheme://$host/scope/;
 }
+
 location ^~ /scope/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
@@ -23,6 +24,4 @@ location ^~ /scope/ {
     proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
     rewrite /scope(.*) $1 break;
-    proxy_set_header Upgrade $http_upgrade;
-	proxy_set_header Connection "upgrade";
 }

--- a/sickchill.subdomain.conf.sample
+++ b/sickchill.subdomain.conf.sample
@@ -36,8 +36,6 @@ server {
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
         proxy_set_header Host $http_host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 }

--- a/sickchill.subfolder.conf.sample
+++ b/sickchill.subfolder.conf.sample
@@ -20,8 +20,6 @@ location ^~ /sickchill {
     proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
     proxy_set_header Host $http_host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
 
 }

--- a/synclounge.subdomain.conf.sample
+++ b/synclounge.subdomain.conf.sample
@@ -40,8 +40,6 @@ server {
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
     }
 
     ###
@@ -57,9 +55,6 @@ server {
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
-
     }
 
     # Due to a bug in SyncLounge, some websockets calls don't respect the base url (server root) setting
@@ -70,9 +65,6 @@ server {
         set $upstream_port 8089;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port/slserver/socket.io/;
-
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
 
     }
 }

--- a/synclounge.subfolder.conf.sample
+++ b/synclounge.subfolder.conf.sample
@@ -15,7 +15,6 @@
 #        }
 #}
 
-
 # Uncomment to force SyncLounge to always load over http. Only use this if you've allowed http per the above instructions.
 #if ($scheme = https) {
 #    return 301 http://$host$request_uri;
@@ -54,10 +53,8 @@ location /slweb {
 
     proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection "upgrade";
-
 }
+
 if ($http_referer ~* /slweb) {
     # Some requests like /config don't respect the base url (web root) setting
     rewrite ^/config /slweb/config redirect;
@@ -79,10 +76,8 @@ location /slserver {
 
     proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection "upgrade";
-
 }
+
 if ($http_referer ~* /slserver) {
     # Some requests like socket.io don't respect the base url (server root) setting
     rewrite ^/socket.io/(.*) /slserver/socket.io/$1? redirect;

--- a/taisun.subdomain.conf.sample
+++ b/taisun.subdomain.conf.sample
@@ -36,8 +36,5 @@ server {
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
         proxy_buffering off;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection $http_connection;
     }
-
 }

--- a/thelounge.subfolder.conf.sample
+++ b/thelounge.subfolder.conf.sample
@@ -3,6 +3,7 @@
 location /thelounge {
     return 301 $scheme://$host/thelounge/;
 }
+
 location ^~ /thelounge/ {
     # enable the next two lines for http auth
     #auth_basic "Restricted";

--- a/unifi-controller.subdomain.conf.sample
+++ b/unifi-controller.subdomain.conf.sample
@@ -1,4 +1,6 @@
 # make sure that your dns has a cname set for unifi and that your unifi-controller container is not using a base url
+# NOTE: If you use the proxy_cookie_path setting in proxy.conf you need to remove HTTPOnly;
+# ex: proxy_cookie_path / "/; Secure";
 
 server {
     listen 443 ssl;
@@ -35,31 +37,6 @@ server {
         set $upstream_proto https;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
-    }
-
-    location /wss {
-        # enable the next two lines for http auth
-        #auth_basic "Restricted";
-        #auth_basic_user_file /config/nginx/.htpasswd;
-
-        # enable the next two lines for ldap auth
-        #auth_request /auth;
-        #error_page 401 =200 /ldaplogin;
-
-        # enable for Authelia
-        #include /config/nginx/authelia-location.conf;
-
-        include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
-        set $upstream_app unifi-controller;
-        set $upstream_port 8443;
-        set $upstream_proto https;
-        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
-
         proxy_buffering off;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "Upgrade";
-        proxy_ssl_verify off;
     }
-
 }

--- a/youtube-dl.subfolder.conf.sample
+++ b/youtube-dl.subfolder.conf.sample
@@ -12,17 +12,16 @@ location ^~ /youtube-dl/ {
     # enable the next two lines for ldap auth, also customize and enable ldap.conf in the default conf
     #auth_request /auth;
     #error_page 401 =200 /login;
-	
+
     include /config/nginx/proxy.conf;
     resolver 127.0.0.11 valid=30s;
     set $upstream_app  youtube-dl-server;
     set $upstream_port 8080;
     set $upstream_proto http;
     proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
     proxy_redirect  off;
-	
-    rewrite /youtube-dl(.*) $1 break;
-	
     proxy_set_header Referer '';
     proxy_set_header Host $upstream_app:8080;
+    rewrite /youtube-dl(.*) $1 break;
 }


### PR DESCRIPTION
Also general cleanup of whitespace

Ref: https://github.com/linuxserver/docker-swag/pull/7
Probably merge this first!

I have manually tested and confirmed:
bitwarden
code-server
plex
unifi-controller (a lot of testing went into this one!)
lidarr
sonarr
radarr

Closes https://github.com/linuxserver/reverse-proxy-confs/pull/191