### PR TITLE
Fix for connecting to container Cline

### DIFF
--- a/portainer.subfolder.conf.sample
+++ b/portainer.subfolder.conf.sample
@@ -36,5 +36,7 @@ location ^~ /portainer/api/websocket/ {
     proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
     rewrite /portainer(.*) $1 break;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
     proxy_hide_header X-Frame-Options; # Possibly not needed after Portainer 1.20.0
 }


### PR DESCRIPTION
W/out these 2 lines you'll get the following error (or similar) while trying to connect to a container in portainer's web ui:

> WebSocket connection to 'wss://<domain>/portainer/api/websocket/exec?token=<token>=6&id=<id>&nodeName=docker-desktop' failed: Error during WebSocket handshake: Unexpected response code: 400

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

