### PR TITLE
Collabora: Set extra headers for websocket URIs

### DIFF
--- a/collabora.subdomain.conf.sample
+++ b/collabora.subdomain.conf.sample
@@ -49,6 +49,8 @@ server {
         set $upstream_proto https;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
         proxy_set_header Host $http_host;
         proxy_read_timeout 36000s;
     }
@@ -72,6 +74,8 @@ server {
         set $upstream_proto https;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
         proxy_set_header Host $http_host;
         proxy_read_timeout 36000s;
     }


### PR DESCRIPTION
Was not able to get Collabora working with Nextcloud without these edits
