### PR TITLE
Added Overseerr Sample Conf - Issue #251

### DIFF
--- a/overseerr.subdomain.conf.sample
+++ b/overseerr.subdomain.conf.sample
@@ -13,7 +13,7 @@ server {
 
         include /config/nginx/proxy.conf;
         resolver 127.0.0.11 valid=30s;
-        set $upstream_app 192.168.178.100;
+        set $upstream_app overseerr;
         set $upstream_port 5055;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;

--- a/overseerr.subdomain.conf.sample
+++ b/overseerr.subdomain.conf.sample
@@ -1,0 +1,23 @@
+## Version 2020/12/18
+# make sure that your dns has a cname set for overseerr and that your overseerr container is named overseerr
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+
+    server_name overseerr.*;
+
+    include /config/nginx/ssl.conf;
+
+    location / {
+
+        include /config/nginx/proxy.conf;
+        resolver 127.0.0.11 valid=30s;
+        set $upstream_app 192.168.178.100;
+        set $upstream_port 5055;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    }
+
+}


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

This PR handles my wish for a working overseerr sample config. Descirbed as in Issue #251  
I just created another file: https://github.com/Sakujakira/reverse-proxy-confs/blob/Overseerr-Conf/overseerr.subdomain.conf.sample 

##  Thanks, team linuxserver.io

