### PR TITLE
Add filebrowser.subdomain.conf.sample

### DIFF
--- a/filebrowser.subdomain.conf.sample
+++ b/filebrowser.subdomain.conf.sample
@@ -1,0 +1,49 @@
+## Version 2021/01/03
+# make sure that your dns has a cname set for filebrowser and that your filebrowser container is not using a base url
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name <container_name>.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    # enable for ldap auth, fill in ldap details in ldap.conf
+    #include /config/nginx/ldap.conf;
+
+    # enable for Authelia
+    #include /config/nginx/authelia-server.conf;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable the next two lines for ldap auth
+        #auth_request /auth;
+        #error_page 401 =200 /ldaplogin;
+
+        # enable for Authelia
+        #include /config/nginx/authelia-location.conf;
+
+        include /config/nginx/proxy.conf;
+        resolver 127.0.0.11 valid=30s;
+        set $upstream_app filebrowser;
+        set $upstream_port 8080;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+    }
+
+    # Allow anonymous access to shared files/folders when auth is enabled
+    location ~ /(static|share|api/public)/ {
+        include /config/nginx/proxy.conf;
+        resolver 127.0.0.11 valid=30s;
+        set $upstream_app filebrowser;
+        set $upstream_port 8080;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+    }
+}

--- a/filebrowser.subdomain.conf.sample
+++ b/filebrowser.subdomain.conf.sample
@@ -5,7 +5,7 @@ server {
     listen 443 ssl;
     listen [::]:443 ssl;
 
-    server_name <container_name>.*;
+    server_name filebrowser.*;
 
     include /config/nginx/ssl.conf;
 


### PR DESCRIPTION
Adds support for [File Browser](https://filebrowser.org/)

Includes support for anonymous access to shared files/folders when external auth is enabled

