### PR TITLE
Update znc.subdomain.conf.sample

### DIFF
--- a/znc.subdomain.conf.sample
+++ b/znc.subdomain.conf.sample
@@ -1,6 +1,8 @@
 ## Version 2020/12/09
 # make sure that your dns has a cname set for znc
-
+# To additionally port foward the irc port uncomment the stream section in /config/nginx/nginx.conf, Add SSL port 6502 and append these lines (without #) to znc.conf:
+#TrustedProxy = 127.0.0.1
+#TrustedProxy = ::1
 server {
     listen 443 ssl;
     listen [::]:443 ssl;


### PR DESCRIPTION
I've successfully port forwarded the IRC port for znc but this won't work without the addition of the stream section in nginx.conf
To be very clear this addition is not for http but to proxy the irc port through swag.
Nginx will accept port 6502 on any subdomain and pass it through to znc, My reasoning for doing it is to avoid configuring ssl certificates in znc.
https://wiki.znc.in/Reverse_Proxy
https://nginx.org/en/docs/stream/ngx_stream_core_module.html

For more info see: https://github.com/linuxserver/docker-swag/pull/58

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

