### PR TITLE
Handle Nginx http auth + grafana auth separately

### DIFF
--- a/grafana.subdomain.conf.sample
+++ b/grafana.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2020/12/09
+## Version 2021/01/29
 # make sure that your dns has a cname set for grafana and that your grafana container is not using a base url
 
 server {
@@ -35,6 +35,9 @@ server {
         set $upstream_port 3000;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+        
+        # Clear Authorization Header if you are using http auth and normal Grafana auth
+        #proxy_set_header    Authorization       "";        
 
     }
 }

--- a/grafana.subfolder.conf.sample
+++ b/grafana.subfolder.conf.sample
@@ -22,6 +22,10 @@ location ^~ /grafana/ {
     set $upstream_port 3000;
     set $upstream_proto http;
     proxy_pass http://$upstream_grafana:$upstream_port ;
+    
+    # Clear Authorization Header if you are using http auth and normal Grafana auth
+    #proxy_set_header    Authorization       "";
+    
     rewrite ^/grafana/(.*)$ /$1 break;
 
 }

--- a/grafana.subfolder.conf.sample
+++ b/grafana.subfolder.conf.sample
@@ -1,4 +1,4 @@
-## Version 2020/12/09
+## Version 2021/01/29
 # grafana requires environment variables set thus:
 #    environment:
 #      - "GF_SERVER_ROOT_URL=https://my.domain.com/grafana"


### PR DESCRIPTION
Went down a rabbit hole because I had my "admin" type subdirectory protected by http auth, but the individual apps have their own user auth. The passed authorization header was causing problems with Grafana.
