### PR TITLE
Update pixelfed.subdomain.conf.sample

### DIFF
--- a/pixelfed.subdomain.conf.sample
+++ b/pixelfed.subdomain.conf.sample
@@ -1,5 +1,6 @@
-## Version 2020/12/09
-# make sure that your dns has a cname set for pixelfed and the container is named pixelfed
+## Version 2021/01/29
+# make sure that your dns has a cname set for pixelfed and the container is named pixelfed_app_1
+# Note: pixelfed_app_1 is the default name in the docker config files of pixelfed
 
 server {
     listen 443 ssl;
@@ -31,7 +32,7 @@ server {
 
         include /config/nginx/proxy.conf;
         resolver 127.0.0.11 valid=30s;
-        set $upstream_app pixelfed;
+        set $upstream_app pixelfed_app_1;
         set $upstream_port 80;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;


### PR DESCRIPTION
pixelfed realeased today the latest version 0.10.10 with default docker and docker-compose configuration.
Using their default setup the container ame is "pixelfed_app_1" not just "pixelfed".
The subdomain pixelfed can stay the same.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

