### PR TITLE
Error Fix for latest version of youtube-dl

### DIFF
--- a/youtube-dl.subfolder.conf.sample
+++ b/youtube-dl.subfolder.conf.sample
@@ -23,6 +23,7 @@ location ^~ /youtube-dl/ {
 
     proxy_redirect  off;
     proxy_set_header Referer '';
-    proxy_set_header Host $upstream_app:8080;
+    # next line doesn't work with the latest version of: https://github.com/nbr23/youtube-dl-server
+    # proxy_set_header Host $upstream_app:8080;
     rewrite /youtube-dl(.*) $1 break;
 }


### PR DESCRIPTION
Fixes error with combination of nginx and starlette

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

Error encountert after changing to starlette.
Double host naming in proxy config makes trouble.
https://github.com/nbr23/youtube-dl-server/issues/31


##  Thanks, team linuxserver.io

