### PR TITLE
Add support for the various aria2-with-webui images

### DIFF
--- a/aria2-with-webui.subdomain.conf.sample
+++ b/aria2-with-webui.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2020/12/09
+## Version 2021/05/18
 # Make sure that your dns has a cname set for aria2 and that your aria2-with-webui container is not using a base url
 #
 # The RPC port will need to be changed to 443 in the AriaNg/WebUI-Aria2 settings or by using the AriaNg command api
@@ -34,7 +34,7 @@ server {
         #include /config/nginx/authelia-location.conf;
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
+        include /config/nginx/resolver.conf;
         set $upstream_app aria2-with-webui;
         set $upstream_port 80;
         set $upstream_proto http;
@@ -44,7 +44,7 @@ server {
 	
     location ~ (/aria2-with-webui)?/jsonrpc {
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
+        include /config/nginx/resolver.conf;
         set $upstream_app aria2-with-webui;
         set $upstream_port 6800;
         set $upstream_proto http;
@@ -54,7 +54,7 @@ server {
 
     location ~ (/aria2-with-webui)?/rpc {
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
+        include /config/nginx/resolver.conf;
         set $upstream_app aria2-with-webui;
         set $upstream_port 6800;
         set $upstream_proto http;

--- a/aria2-with-webui.subdomain.conf.sample
+++ b/aria2-with-webui.subdomain.conf.sample
@@ -1,0 +1,64 @@
+## Version 2020/12/09
+# Make sure that your dns has a cname set for aria2 and that your aria2-with-webui container is not using a base url
+#
+# The RPC port will need to be changed to 443 in the AriaNg/WebUI-Aria2 settings or by using the AriaNg command api
+# e.g. https://aria2.example.com/#!/settings/rpc/set/https/aria2.example.com/443/jsonrpc
+#      https://aria2.example.com/#!/settings/rpc/set?protocol=https&host=aria2.example.com&port=443&interface=aria2-with-webui/jsonrpc
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name aria2.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    # enable for ldap auth, fill in ldap details in ldap.conf
+    #include /config/nginx/ldap.conf;
+
+    # enable for Authelia
+    #include /config/nginx/authelia-server.conf;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable the next two lines for ldap auth
+        #auth_request /auth;
+        #error_page 401 =200 /ldaplogin;
+
+        # enable for Authelia
+        #include /config/nginx/authelia-location.conf;
+
+        include /config/nginx/proxy.conf;
+        resolver 127.0.0.11 valid=30s;
+        set $upstream_app aria2-with-webui;
+        set $upstream_port 80;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    }
+	
+    location ~ (/aria2-with-webui)?/jsonrpc {
+        include /config/nginx/proxy.conf;
+        resolver 127.0.0.11 valid=30s;
+        set $upstream_app aria2-with-webui;
+        set $upstream_port 6800;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port/jsonrpc;
+
+    }
+
+    location ~ (/aria2-with-webui)?/rpc {
+        include /config/nginx/proxy.conf;
+        resolver 127.0.0.11 valid=30s;
+        set $upstream_app aria2-with-webui;
+        set $upstream_port 6800;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port/rpc;
+
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

This adds support for the various aria2-with-webui images that are available.

Both the JSON-RPC and JSON-XML interfaces are catered for but I have only tested the JSON-RPC interface using the onisuly/aria2-with-webui image.