### PR TITLE
Add Foundry VTT subdomain

### DIFF
--- a/foundryvtt.subdomain.conf.sample
+++ b/foundryvtt.subdomain.conf.sample
@@ -1,0 +1,45 @@
+## Version 2021/03/06
+# make sure that your dns has a cname set for <container_name> and that your <container_name> container is not using a base url
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name foundry.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 300M;
+
+    # enable for ldap auth, fill in ldap details in ldap.conf
+    #include /config/nginx/ldap.conf;
+
+    # enable for Authelia
+    #include /config/nginx/authelia-server.conf;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable the next two lines for ldap auth
+        #auth_request /auth;
+        #error_page 401 =200 /ldaplogin;
+
+        # enable for Authelia
+        #include /config/nginx/authelia-location.conf;
+
+        include /config/nginx/proxy.conf;
+        resolver 127.0.0.11 valid=30s;
+        set $upstream_app <container-name>;
+        set $upstream_port <port>;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+        # Set proxy headers
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+    }
+}

--- a/foundryvtt.subdomain.conf.sample
+++ b/foundryvtt.subdomain.conf.sample
@@ -31,8 +31,8 @@ server {
 
         include /config/nginx/proxy.conf;
         resolver 127.0.0.11 valid=30s;
-        set $upstream_app <container-name>;
-        set $upstream_port <port>;
+        set $upstream_app foundry;
+        set $upstream_port 30000;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 


### PR DESCRIPTION
Added capabillity for hosting [Foundry VTT](https://foundryvtt.com/).

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	
Aiming to resolve Issue #303 

##  Thanks, team linuxserver.io

