### PR TITLE
Add additional headers for quassel-web

### DIFF
--- a/quassel-web.subdomain.conf.sample
+++ b/quassel-web.subdomain.conf.sample
@@ -37,5 +37,11 @@ server {
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $host;
+        proxy_redirect off;
     }
 }

--- a/quassel-web.subfolder.conf.sample
+++ b/quassel-web.subfolder.conf.sample
@@ -21,4 +21,10 @@ location ^~ /quassel {
     set $upstream_proto http;
     proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $host;
+    proxy_redirect off;
 }


### PR DESCRIPTION
These are taken from the quassel-webserver readme[1]. Without them, the client would fail to connect to the core with messages like:

    Unchecked runtime.lastError: The message port closed before a response was received.

n.b. I was only able to test this with the subfolder configuration, but I added the headers to both configurations for consistency.

[1] https://github.com/magne4000/quassel-webserver/blob/8e3201fa1f6733ae77a351b3694e33b0906a2728/README.md#nginx