### PR TITLE
Create a mealie.subdomain.conf.sample for mealie recipe app

### DIFF
--- a/mealie.subdomain.conf.sample
+++ b/mealie.subdomain.conf.sample
@@ -14,7 +14,7 @@ server {
     location / {
 
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
+        include /config/nginx/resolver.conf;
         set $upstream_app mealie;
         set $upstream_port 80;
         set $upstream_proto http;

--- a/mealie.subdomain.conf.sample
+++ b/mealie.subdomain.conf.sample
@@ -1,0 +1,26 @@
+## Version 2021/05/21
+# Ensure your DNS has a CNAME set for mealie and that mealie container is not using a base URL.
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name mealie.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    location / {
+
+        include /config/nginx/proxy.conf;
+        resolver 127.0.0.11 valid=30s;
+        set $upstream_app mealie;
+        set $upstream_port 80;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    }
+
+
+}


### PR DESCRIPTION


[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

