### PR TITLE
working homeassistant.subdomain.conf config file

### DIFF
--- a/homeassistant.subdomain.conf.sample
+++ b/homeassistant.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2021/05/18
+## Version 2021-05-30
 # make sure that your dns has a cname set for homeassistant and that your homeassistant container is not using a base url
 
 server {
@@ -16,6 +16,9 @@ server {
 
     # enable for Authelia
     #include /config/nginx/authelia-server.conf;
+    
+    # in case the service is running on `host` networking
+    # set $upstream_IP <your.HA.instance.IP>
 
     location / {
         # enable the next two lines for http auth
@@ -35,7 +38,14 @@ server {
         set $upstream_port 8123;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+        
+        # in case the service is running on `host` networking, use this instead:
+        # proxy_pass $upstream_proto://$upstream_IP:$upstream_port;
 
+        # these seem to be needed:
+        proxy_set_header Host $host;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
     }
     
     location /api {
@@ -45,5 +55,13 @@ server {
         set $upstream_port 8123;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+        
+        # in case the service is running on `host` networking, use this instead:
+        # proxy_pass $upstream_proto://$upstream_IP:$upstream_port;
+
+        # these seem to be needed:
+        proxy_set_header Host $host;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
     }
 }

--- a/homeassistant.subdomain.conf.sample
+++ b/homeassistant.subdomain.conf.sample
@@ -41,11 +41,6 @@ server {
         
         # in case the service is running on `host` networking, use this instead:
         # proxy_pass $upstream_proto://$upstream_IP:$upstream_port;
-
-        # these seem to be needed:
-        proxy_set_header Host $host;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
     }
     
     location /api {
@@ -59,8 +54,6 @@ server {
         # in case the service is running on `host` networking, use this instead:
         # proxy_pass $upstream_proto://$upstream_IP:$upstream_port;
 
-        # these seem to be needed:
-        proxy_set_header Host $host;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
     }

--- a/homeassistant.subdomain.conf.sample
+++ b/homeassistant.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2021-05-30
+## Version 2021/05/30
 # make sure that your dns has a cname set for homeassistant and that your homeassistant container is not using a base url
 
 server {


### PR DESCRIPTION
1. Some headers seem to always be necessary.
2. I also added a (commented out) way to configure this module, as on my side, I don't want my HA instance to be reachable solely over https -- I also want to be able to reach the instance locally even when the outside internet connection is down.

I'm not aware of any bug open for these, however I've seen a number of people in forums struggling with this.
