### PR TITLE
Created Foundry VTT Subdomain sample

### DIFF
--- a/foundryvtt.subdomain.conf.sample
+++ b/foundryvtt.subdomain.conf.sample
@@ -1,5 +1,14 @@
 ## Version 2021/06/05
-# make sure that your dns has a cname set for foundryvtt
+# make sure that your dns has a cname set for foundryvtt 
+# Ensure that your Foundry VTT's {userData}/Config/options.json file is configured as follows: 
+# "hostname": "your.hostname.com",
+# "routePrefix": null,
+# "sslCert": null,
+# "sslKey": null,
+# "port": 30000,
+# "proxyPort": 443,
+# "proxySSL": true
+# Refer to https://foundryvtt.com/article/nginx/ for the latest Foundry configuration information
 
 server {
     listen 443 ssl;

--- a/foundryvtt.subdomain.conf.sample
+++ b/foundryvtt.subdomain.conf.sample
@@ -1,0 +1,40 @@
+## Version 2021/06/05
+# make sure that your dns has a cname set for foundryvtt
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name foundryvtt.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 300M;
+
+    # enable for ldap auth, fill in ldap details in ldap.conf
+    #include /config/nginx/ldap.conf;
+
+    # enable for Authelia
+    #include /config/nginx/authelia-server.conf;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable the next two lines for ldap auth
+        #auth_request /auth;
+        #error_page 401 =200 /ldaplogin;
+
+        # enable for Authelia
+        #include /config/nginx/authelia-location.conf;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app foundryvtt;
+        set $upstream_port 30000;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+		
+    }
+}


### PR DESCRIPTION
Added a subdomain config sample for [FoundryVTT](https://foundryvtt.com/). Usable with any of the various FoundryVTT docker images, such as [this one.](https://github.com/felddy/foundryvtt-docker).

Config is based off of FoundryVTT's [own guidelines](https://foundryvtt.com/article/nginx/).

Note: There's already a PR for a FoundryVTT config, #304 but it seems to have gone stale so rather than complain I've attempted this myself.

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

