### PR TITLE
Update the Adguard example to encompass first run

### DIFF
--- a/adguard.subdomain.conf.sample
+++ b/adguard.subdomain.conf.sample
@@ -1,5 +1,7 @@
-## Version 2021/05/18
+## Version 2021/06/09
 # make sure that your dns has a cname set for adguard and that your adguard container is named adguard
+# After first run, update the port of the app to port 80
+
 
 server {
     listen 443 ssl;
@@ -32,7 +34,9 @@ server {
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
         set $upstream_app adguard;
-        set $upstream_port 80;
+        set $upstream_port 3000;
+        # After first run, comment line above and uncomment line below
+        # set $upstream_port 80; 
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
@@ -42,7 +46,9 @@ server {
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
         set $upstream_app adguard;
-        set $upstream_port 80;
+        set $upstream_port 3000;
+        # After first run, comment line above and uncomment line below
+        # set $upstream_port 80; 
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 


### PR DESCRIPTION
On first run, the forward should go to port 3000 instead of port 80. After installing, port 80 is the correct one.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

