### PR TITLE
Change to default value for proxy_max_temp_file_size

### DIFF
--- a/nextcloud.subdomain.conf.sample
+++ b/nextcloud.subdomain.conf.sample
@@ -31,6 +31,6 @@ server {
         set $upstream_proto https;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
-        proxy_max_temp_file_size 2048m;
+        proxy_max_temp_file_size 1024m;
     }
 }


### PR DESCRIPTION
Received proxy_max_temp_file_size invalid. Checked http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_max_temp_file_size and 1024 is the default.

<!--- Provide a general summary of your changes in the Title above -->
Fixes issue #239 by changing proxy_max_temp_file_size to default value.
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

