### PR TITLE
Added influxdb.subdomain.conf.sample

### DIFF
--- a/influxdb.subdomain.conf.sample
+++ b/influxdb.subdomain.conf.sample
@@ -1,0 +1,40 @@
+## Version 2021/06/20
+# make sure that your dns has a cname set for <container_name> and that your <container_name> container is not using a base url
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name influxdb.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    # enable for ldap auth, fill in ldap details in ldap.conf
+    #include /config/nginx/ldap.conf;
+
+    # enable for Authelia
+    #include /config/nginx/authelia-server.conf;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable the next two lines for ldap auth
+        #auth_request /auth;
+        #error_page 401 =200 /ldaplogin;
+
+        # enable for Authelia
+        #include /config/nginx/authelia-location.conf;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app influxdb;
+        set $upstream_port 8086;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+    }
+}
+

--- a/influxdb.subdomain.conf.sample
+++ b/influxdb.subdomain.conf.sample
@@ -1,5 +1,5 @@
 ## Version 2021/06/20
-# make sure that your dns has a cname set for <container_name> and that your <container_name> container is not using a base url
+# make sure that your dns has a cname set for influxdb and that your influxdb container is not using a base url
 
 server {
     listen 443 ssl;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This is a sample subdomain-based config for InfluxDB. It has been tested with version 1.8 and 2.0. No special configuration is needed.

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
