### PR TITLE
Add missing semicolon

### DIFF
--- a/papermerge.subdomain.conf.sample
+++ b/papermerge.subdomain.conf.sample
@@ -30,7 +30,7 @@ server {
         #include /config/nginx/authelia-location.conf;
 
         include /config/nginx/proxy.conf;
-        include /config/nginx/resolver.conf
+        include /config/nginx/resolver.conf;
         set $upstream_app papermerge;
         set $upstream_port 8000;
         set $upstream_proto http;


### PR DESCRIPTION
Missing semicolon on line 34 results in invalid config file, which prevents the nginx from properly starting

`nginx: [emerg] invalid number of arguments in "include" directive in /config/nginx/proxy-confs/papermerge.subdomain.conf:34`


