### PR TITLE
Bypass Authelia auth for Calibre-Web OPDS feed

### DIFF
--- a/calibre-web.subdomain.conf.sample
+++ b/calibre-web.subdomain.conf.sample
@@ -27,6 +27,9 @@ server {
         #error_page 401 =200 /ldaplogin;
 
         # enable for Authelia
+        # To use Authelia to log in to Calibre-Web, make sure "Reverse Proxy Login" is 
+        # enabled, "Reverse Proxy Header Name" is set to Remote-User, and each Authelia
+        # user also has a corresponding user manually created in Calibre-Web.
         #include /config/nginx/authelia-location.conf;
 
         include /config/nginx/proxy.conf;
@@ -36,6 +39,20 @@ server {
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
+        proxy_set_header X-Scheme $scheme;
+    }
+	
+	# OPDS feed for eBook reader apps
+	# Even if you use Authelia, the OPDS feed requires a password to be set for
+	# the user directly in Calibre-Web, as eBook reader apps don't support 
+	# form-based logins, only HTTP Basic auth.
+    location /opds/ {
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app calibre-web;
+        set $upstream_port 8083;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
         proxy_set_header X-Scheme $scheme;
     }
 }

--- a/calibre-web.subfolder.conf.sample
+++ b/calibre-web.subfolder.conf.sample
@@ -15,6 +15,9 @@ location ^~ /calibre-web/ {
     #error_page 401 =200 /ldaplogin;
 
     # enable for Authelia, also enable authelia-server.conf in the default site config
+    # To use Authelia to log in to Calibre-Web, make sure "Reverse Proxy Login" is 
+    # enabled, "Reverse Proxy Header Name" is set to Remote-User, and each Authelia
+    # user also has a corresponding user manually created in Calibre-Web.
     #include /config/nginx/authelia-location.conf;
 
     include /config/nginx/proxy.conf;
@@ -24,6 +27,21 @@ location ^~ /calibre-web/ {
     set $upstream_proto http;
     proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
+    proxy_set_header X-Scheme $scheme;
+    proxy_set_header X-Script-Name /calibre-web;
+}
+
+# OPDS feed for eBook reader apps
+# Even if you use Authelia, the OPDS feed requires a password to be set for
+# the user directly in Calibre-Web, as eBook reader apps don't support 
+# form-based logins, only HTTP Basic auth.
+location ^~ /calibre-web/opds/ {
+    include /config/nginx/proxy.conf;
+    include /config/nginx/resolver.conf;
+    set $upstream_app calibre-web;
+    set $upstream_port 8083;
+    set $upstream_proto http;
+    proxy_pass $upstream_proto://$upstream_app:$upstream_port;
     proxy_set_header X-Scheme $scheme;
     proxy_set_header X-Script-Name /calibre-web;
 }


### PR DESCRIPTION
eBook apps do not support fancy form-based authentication nor two-factor auth, like what's provided by Authelia. This PR updates the config to bypass Authelia for the `/opds/...` endpoints. I verified that this allows me to use Calibre-Web's OPDS feed with Moon+ Reader on Android.

I also added a comment about how to enable Authelia single sign-on support in Calibre-Web. Let me know if you'd prefer this to be mentioned in the docs instead.