### PR TITLE
Add additional location for /confirmdeletion

### DIFF
--- a/qbittorrent.subdomain.conf.sample
+++ b/qbittorrent.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2021/05/18
+## Version 2021/07/25
 # make sure that your dns has a cname set for qbittorrent and that your qbittorrent container is not using a base url
 
 server {
@@ -97,6 +97,20 @@ server {
     }
 
     location ~ (/qbittorrent)?/sync {
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app qbittorrent;
+        set $upstream_port 8080;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+        rewrite /qbittorrent(.*) $1 break;
+
+        proxy_set_header Referer '';
+        proxy_set_header Host $upstream_app:$upstream_port;
+    }
+    
+    location ~ (/qbittorrent)?/confirmdeletion {
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
         set $upstream_app qbittorrent;


### PR DESCRIPTION
Adding location for /confirmdeletion for better compatibility with Authelia.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

