### PR TITLE
Add proxy_set_header X-Scheme https;

### DIFF
--- a/octoprint.subdomain.conf.sample
+++ b/octoprint.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2021/06/16
+## Version 2021/09/05
 # make sure that your dns has a cname set for octoprint and that your octoprint container is not using a base url
 
 server {
@@ -35,6 +35,7 @@ server {
         set $upstream_port 80;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+        proxy_set_header X-Scheme https;
 
     }
 


### PR DESCRIPTION
The X-scheme header seems to be required for Octoprint to correctly use Websockets.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

