### PR TITLE
Auto redirect for non-standard port

### DIFF
--- a/calibre-web.subdomain.conf.sample
+++ b/calibre-web.subdomain.conf.sample
@@ -54,5 +54,6 @@ server {
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
         proxy_set_header X-Scheme $scheme;
+	proxy_redirect https://$host/ https://$host:selfdefined port number/;#here use your self-defined port number, so it could redirect to other link then still keep self defined port number.
     }
 }


### PR DESCRIPTION
Purpose to add function to auto redirect to non-standard port when server works on non-standard port condition.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

