### PR TITLE
Adguard add support for dns query

### DIFF
--- a/adguard.subdomain.conf.sample
+++ b/adguard.subdomain.conf.sample
@@ -49,6 +49,8 @@ server {
     }
     
     location /dns-query {
+        # to properly use this please set `allow_unencrypted_doh: true` and `force_https: false` in adguard
+        # see https://github.com/AdguardTeam/AdGuardHome/wiki/Configuration#configuration-file
         include /config/nginx/proxy.conf;
         resolver 127.0.0.11 valid=30s;
         set $upstream_app adguard;

--- a/adguard.subdomain.conf.sample
+++ b/adguard.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2021/05/18
+## Version 2021/09/24
 # make sure that your dns has a cname set for adguard and that your adguard container is named adguard
 
 server {
@@ -52,7 +52,7 @@ server {
         # to properly use this please set `allow_unencrypted_doh: true` and `force_https: false` in adguard
         # see https://github.com/AdguardTeam/AdGuardHome/wiki/Configuration#configuration-file
         include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
+        include /config/nginx/resolver.conf;
         set $upstream_app adguard;
         set $upstream_port 80;
         set $upstream_proto http;

--- a/adguard.subdomain.conf.sample
+++ b/adguard.subdomain.conf.sample
@@ -47,4 +47,14 @@ server {
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
     }
+    
+    location /dns-query {
+        include /config/nginx/proxy.conf;
+        resolver 127.0.0.11 valid=30s;
+        set $upstream_app adguard;
+        set $upstream_port 80;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    }
 }


### PR DESCRIPTION
Allow `/dns-query` on AdGuard for DoH.