### PR TITLE
Have return include full URL

### DIFF
--- a/organizr-auth.subfolder.conf.sample
+++ b/organizr-auth.subfolder.conf.sample
@@ -37,4 +37,4 @@ location ~ /auth-([0-9]+) {
 
 # Optional redirect server authentication errors to organizr authentication page
 # NOTE: $host must be modified to your public URL when using subdomain proxies
-#error_page 401 $scheme://$host/?error=$status&return=$request_uri;
+#error_page 401 $scheme://$host/?error=$status&return=$scheme://$http_host$request_uri;


### PR DESCRIPTION
Fixes the return when using subdomains (and doesn't effect subfolders)

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

