### PR TITLE
Check for CRLF, add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+# trim_trailing_whitespace may cause unintended issues and should not be globally set true
+trim_trailing_whitespace = false
+
+[{*.conf,*.conf.sample}]
+indent_style = space
+indent_size = 4

--- a/.github/workflows/check_samples.yml
+++ b/.github/workflows/check_samples.yml
@@ -23,6 +23,16 @@ jobs:
             exit 1
         fi
 
+    - name: Check Line Endings
+      run: |
+        CRLF_ENDINGS=$(find . -not -type d -exec file "{}" ";" | grep CRLF)
+        CRLF_ENDINGS_COUNT=$(echo "${CRLF_ENDINGS}" | wc -w)
+        if (( CRLF_ENDINGS_COUNT > 0 )); then
+            echo "The following files are not allowed:"
+            echo "${CRLF_ENDINGS}"
+            exit 1
+        fi
+
     - name: Check Version Date Line Exists
       run: |
         # Date regex based on https://www.html5pattern.com/Dates

--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,10 @@
 *
 
 # Do NOT ignore allowed files
-!*.conf.sample
+!.editorconfig
 !.gitattributes
 !.github
 !.gitignore
+!*.conf.sample
 !LICENSE
 !README.md


### PR DESCRIPTION
Following up from discussions in https://github.com/linuxserver/reverse-proxy-confs/pull/387 where nothing looked wrong but the issue turned out to be line endings.