### PR TITLE
api, local and media folders shouldn't require auth

### DIFF
--- a/homeassistant.subdomain.conf.sample
+++ b/homeassistant.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2021/07/13
+## Version 2021/10/11
 # make sure that your dns has a cname set for homeassistant and that your homeassistant container is not using a base url
 
 # As of homeassistant 2021.7.0, it is now required to define the network range your proxy resides in, this is done in Homeassitants configuration.yaml
@@ -47,16 +47,7 @@ server {
 
     }
 
-    location /api {
-        include /config/nginx/proxy.conf;
-        include /config/nginx/resolver.conf;
-        set $upstream_app homeassistant;
-        set $upstream_port 8123;
-        set $upstream_proto http;
-        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
-    }
-
-    location /local {
+    location ~ ^/(api|local|media)/ {
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
         set $upstream_app homeassistant;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

There was some discussion about a similar change in #363

I've just configured my HA to use the media browser and I ran into the same issue as before. The media browser exposes media content (eg music) on the `media` path.

I didn't feel like adding a 3rd block with the exact same content, the regex works fine for me.

More info:
https://www.home-assistant.io/more-info/local-media/setup-media/
https://www.home-assistant.io/integrations/media_source/