### PR TITLE
modify seafile config

### DIFF
--- a/seafile.subdomain.conf.sample
+++ b/seafile.subdomain.conf.sample
@@ -1,7 +1,6 @@
 ## Version 2021/05/18
 # For use with the official Seafile Docker image (https://download.seafile.com/published/seafile-manual/docker/deploy%20seafile%20with%20docker.md)
 # Requires that the seafile container uses the following env variables:
-#     SEAFILE_SERVER_LETSENCRYPT=true
 #     SEAFILE_SERVER_HOSTNAME=seafile.yourdomain.com
 # Restart or create the seafile container after enabling this subdomain and restarting the letsencrypt contianer
 
@@ -15,12 +14,29 @@ server {
 
     client_max_body_size 0;
 
+    # enable for ldap auth, fill in ldap details in ldap.conf
+    #include /config/nginx/ldap.conf;
+
+    # enable for Authelia
+    #include /config/nginx/authelia-server.conf;
+
     location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable the next two lines for ldap auth
+        #auth_request /auth;
+        #error_page 401 =200 /ldaplogin;
+
+        # enable for Authelia
+        #include /config/nginx/authelia-location.conf;
+
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
         set $upstream_app seafile;
-        set $upstream_port 443;
-        set $upstream_proto https;
+        set $upstream_port 80;
+        set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
     }


### PR DESCRIPTION
couple issues with this as-is. 
1) SEAFILE_SERVER_LETSENCRYPT=true tells seafile to request a letsencrypt certs which is superfluous if using swag.
2) SEAFILE_SERVER_HOSTNAME= also seems relevant to the cert request process, though it may be needed, so i wont kill it in this PR

it's superfluous to proxy to 443 when 80 is also listening though this has been reported as causing issues previously so sufficient testing is needed.

it was also missing a bunch of our normal shit so this PR bring it in line with the standard.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

