### PR TITLE
Update nextcloud.subdomain.conf.sample

### DIFF
--- a/nextcloud.subdomain.conf.sample
+++ b/nextcloud.subdomain.conf.sample
@@ -12,6 +12,9 @@
 #    0 => '192.168.0.1:444', # This line may look different on your setup, don't modify it.
 #    1 => 'nextcloud.your-domain.com',
 #  ),
+#
+# The above configuration works with linuxserver/nextcloud. 
+# if you're using the official nextcloud image set $upstream_port 80 and $upstream_proto http
 
 server {
     listen 443 ssl;


### PR DESCRIPTION
Upon struggling with getting this figured out for a while, I realized that this is attempting to gain access to Nextcloud through port 443. This is fine with the linuxserver/nextcloud image, but with the official image it won't work as the official image runs on http and port 80.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

