### PR TITLE
Update jellyfin instructions

### DIFF
--- a/jellyfin.subdomain.conf.sample
+++ b/jellyfin.subdomain.conf.sample
@@ -3,8 +3,9 @@
 # if jellyfin is running in bridge mode and the container is named "jellyfin", the below config should work as is
 # if not, replace the line "set $upstream_app jellyfin;" with "set $upstream_app <containername>;"
 # or "set $upstream_app <HOSTIP>;" for host mode, HOSTIP being the IP address of jellyfin
-# in jellyfin settings, under "Advanced/Networking" change the public https port to 443, leave the local ports as is,
-# and set the "Secure connection mode" to "Handled by reverse proxy"
+# in jellyfin settings, under Networking > Server Address Settings, leave the local ports as is,
+# and leave the "Enable HTTPS" option unchecked.
+# Under Networking > Remote Access Settings, change the public https port to 443.
 
 server {
     listen 443 ssl;

--- a/jellyfin.subfolder.conf.sample
+++ b/jellyfin.subfolder.conf.sample
@@ -3,8 +3,9 @@
 # if jellyfin is running in bridge mode and the container is named "jellyfin", the below config should work as is
 # if not, replace the line "set $upstream_app jellyfin;" with "set $upstream_app <containername>;"
 # or "set $upstream_app <HOSTIP>;" for host mode, HOSTIP being the IP address of jellyfin
-# in jellyfin settings, under "Advanced/Networking" change the public https port to 443, leave the local ports as is, set the base url to "/jellyfin",
-# and set the "Secure connection mode" to "Handled by reverse proxy"
+# in jellyfin settings, under Networking > Server Address Settings,  leave the local ports as is,
+# leave the "Enable HTTPS" option unchecked, and set the base url to "/jellyfin".
+# Under Networking > Remote Access Settings, change the public https port to 443.
 
 location /jellyfin {
     return 301 $scheme://$host/jellyfin/;

--- a/jellyfin.subfolder.conf.sample
+++ b/jellyfin.subfolder.conf.sample
@@ -1,5 +1,4 @@
 ## Version 2021/05/18
-# make sure that your dns has a cname set for jellyfin
 # if jellyfin is running in bridge mode and the container is named "jellyfin", the below config should work as is
 # if not, replace the line "set $upstream_app jellyfin;" with "set $upstream_app <containername>;"
 # or "set $upstream_app <HOSTIP>;" for host mode, HOSTIP being the IP address of jellyfin


### PR DESCRIPTION
As explained here: https://github.com/jellyfin/jellyfin/issues/4332
The "Handled by reverse proxy" option no longer exists in Jellyfin.

This is what I understand to be the equivalent settings currently. I could be wrong, and some of these steps may not be necessary.