### PR TITLE
Create shlink.subdomain.conf.sample

### DIFF
--- a/shlink.subdomain.conf.sample
+++ b/shlink.subdomain.conf.sample
@@ -1,0 +1,43 @@
+## Version 2021/12/30
+# make sure that your dns has a cname set for shlink and that your shlink container is not using a base url
+# NOTE: While the domain name here is 'shlink', the container it really points to is the separate
+# shlink-web-client container. You'll need to make a docker compose stack with both the shlink container (back end)
+# and the shlink-web-client container (Web UI). This will point it to the URL: shlink.<yourdomain.com> for the Web UI
+# while using the shlink back end for the rest.
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name shlink.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    # enable for ldap auth, fill in ldap details in ldap.conf
+    #include /config/nginx/ldap.conf;
+
+    # enable for Authelia
+    #include /config/nginx/authelia-server.conf;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable the next two lines for ldap auth
+        #auth_request /auth;
+        #error_page 401 =200 /ldaplogin;
+
+        # enable for Authelia
+        #include /config/nginx/authelia-location.conf;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app shlink-web-client;
+        set $upstream_port 80;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+    }
+}


### PR DESCRIPTION
This .conf requires 2 containers: the cline back end (https://hub.docker.com/r/shlinkio/shlink), and the separate web ui for it (https://hub.docker.com/r/shlinkio/shlink-web-client).

Read the comment at the top for a bit more on it.

This conf will load the web ui when going to "https://shlink.<etc.>". Made more sense than making it "https://shlink-web-client.<etc.>".

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

