### PR TITLE
Update the server_name for uptime-kuma subdomain from uptime.* to uptime-kuma.*

### DIFF
--- a/uptime-kuma.subdomain.conf.sample
+++ b/uptime-kuma.subdomain.conf.sample
@@ -5,7 +5,7 @@ server {
     listen 443 ssl;
     listen [::]:443 ssl;
 
-    server_name uptime.*;
+    server_name uptime-kuma.*;
 
     include /config/nginx/ssl.conf;
 


### PR DESCRIPTION
This is to keep the consistency. I spent some time before realizing that `uptime-kuma `needs a subdomain as only `uptime` this is a bit misleading and effectively prevents someone from using another container in the same network called just `uptime` which nothing to do with `uptime-kuma`. 

Not sure how this would affect the backward compatibility, just thought of updating it in case this was a mistake. plus the original file added very recently making the impact lower.

Thanks

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

