### PR TITLE
Fix CORS for web clients

### DIFF
--- a/synapse.subdomain.conf.sample
+++ b/synapse.subdomain.conf.sample
@@ -38,5 +38,10 @@ server {
         set $upstream_port 8008;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+        
+    	location /.well-known/matrix/client {
+            default_type application/json;
+            add_header Access-Control-Allow-Origin *;
+    	}
     }
 }


### PR DESCRIPTION
https://matrix-org.github.io/synapse/latest/setup/installation.html

/.well-known/matrix/client needs Access-Control-Allow-Origin * for web clients to work