### PR TITLE
Account for subfolders in *warden

### DIFF
--- a/bitwarden.subdomain.conf.sample
+++ b/bitwarden.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2021/05/18
+## Version 2022/02/08
 # make sure that your dns has a cname set for bitwarden and that your bitwarden container is not using a base url
 # make sure your bitwarden container is named "bitwarden"
 # set the environment variable WEBSOCKET_ENABLED=true on your bitwarden container
@@ -40,7 +40,7 @@ server {
 
     }
 
-    location /admin {
+    location ~ (/bitwarden)?/admin {
         # enable the next two lines for http auth
         #auth_basic "Restricted";
         #auth_basic_user_file /config/nginx/.htpasswd;
@@ -61,7 +61,7 @@ server {
 
     }
 
-    location /notifications/hub {
+    location ~ (/bitwarden)?/notifications/hub {
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
         set $upstream_app bitwarden;
@@ -71,7 +71,7 @@ server {
 
     }
 
-    location /notifications/hub/negotiate {
+    location ~ (/bitwarden)?/notifications/hub/negotiate {
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
         set $upstream_app bitwarden;

--- a/bitwarden.subfolder.conf.sample
+++ b/bitwarden.subfolder.conf.sample
@@ -1,4 +1,4 @@
-## Version 2021/05/18
+## Version 2022/02/08
 ## Environmental Variable DOMAIN=https://<DOMAIN>/bitwarden must be set in bitwarden container including subfolder.
 ## This is using ports 80 and 3012
 location /bitwarden {
@@ -26,7 +26,28 @@ location ^~ /bitwarden/ {
 
 }
 
-location /notifications/hub {
+location ~ (/bitwarden)?/admin {
+    # enable the next two lines for http auth
+    #auth_basic "Restricted";
+    #auth_basic_user_file /config/nginx/.htpasswd;
+
+    # enable the next two lines for ldap auth
+    #auth_request /auth;
+    #error_page 401 =200 /ldaplogin;
+
+    # enable for Authelia
+    #include /config/nginx/authelia-location.conf;
+
+    include /config/nginx/proxy.conf;
+    include /config/nginx/resolver.conf;
+    set $upstream_app vaultwarden;
+    set $upstream_port 80;
+    set $upstream_proto http;
+    proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+}
+
+location ~ (/bitwarden)?/notifications/hub {
     include /config/nginx/proxy.conf;
     include /config/nginx/resolver.conf;
     set $upstream_app bitwarden;
@@ -36,7 +57,7 @@ location /notifications/hub {
 
 }
 
-location /notifications/hub/negotiate {
+location ~ (/bitwarden)?/notifications/hub/negotiate {
     include /config/nginx/proxy.conf;
     include /config/nginx/resolver.conf;
     set $upstream_app bitwarden;

--- a/vaultwarden.subdomain.conf.sample
+++ b/vaultwarden.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2021/05/18
+## Version 2022/02/08
 # make sure that your dns has a cname set for vaultwarden and that your vaultwarden container is not using a base url
 # make sure your vaultwarden container is named "vaultwarden"
 # set the environment variable WEBSOCKET_ENABLED=true on your vaultwarden container
@@ -40,7 +40,7 @@ server {
 
     }
 
-    location /admin {
+    location ~ (/vaultwarden)?/admin {
         # enable the next two lines for http auth
         #auth_basic "Restricted";
         #auth_basic_user_file /config/nginx/.htpasswd;
@@ -61,7 +61,7 @@ server {
 
     }
 
-    location /notifications/hub {
+    location ~ (/vaultwarden)?/notifications/hub {
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
         set $upstream_app vaultwarden;
@@ -71,7 +71,7 @@ server {
 
     }
 
-    location /notifications/hub/negotiate {
+    location ~ (/vaultwarden)?/notifications/hub/negotiate {
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
         set $upstream_app vaultwarden;

--- a/vaultwarden.subfolder.conf.sample
+++ b/vaultwarden.subfolder.conf.sample
@@ -1,4 +1,4 @@
-## Version 2021/05/18
+## Version 2022/02/08
 ## Environmental Variable DOMAIN=https://<DOMAIN>/vaultwarden must be set in vaultwarden container including subfolder.
 ## This is using ports 80 and 3012
 location /vaultwarden {
@@ -26,7 +26,28 @@ location ^~ /vaultwarden/ {
 
 }
 
-location /notifications/hub {
+location ~ (/vaultwarden)?/admin {
+    # enable the next two lines for http auth
+    #auth_basic "Restricted";
+    #auth_basic_user_file /config/nginx/.htpasswd;
+
+    # enable the next two lines for ldap auth
+    #auth_request /auth;
+    #error_page 401 =200 /ldaplogin;
+
+    # enable for Authelia
+    #include /config/nginx/authelia-location.conf;
+
+    include /config/nginx/proxy.conf;
+    include /config/nginx/resolver.conf;
+    set $upstream_app vaultwarden;
+    set $upstream_port 80;
+    set $upstream_proto http;
+    proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+}
+
+location ~ (/vaultwarden)?/notifications/hub {
     include /config/nginx/proxy.conf;
     include /config/nginx/resolver.conf;
     set $upstream_app vaultwarden;
@@ -36,7 +57,7 @@ location /notifications/hub {
 
 }
 
-location /notifications/hub/negotiate {
+location ~ (/vaultwarden)?/notifications/hub/negotiate {
     include /config/nginx/proxy.conf;
     include /config/nginx/resolver.conf;
     set $upstream_app vaultwarden;


### PR DESCRIPTION
This closes https://github.com/linuxserver/reverse-proxy-confs/issues/418

- The `/admin` endpoint was missing from the subfolder confs
- All subfolder endpoints have been prefixed to work with or without `/bitwarden` or `/vaultwarden` respectively, whether using the subfolder or subdomain proxy sample