### PR TITLE
Adding homer subfolder conf

### DIFF
--- a/homer.subfolder.conf.sample
+++ b/homer.subfolder.conf.sample
@@ -1,0 +1,27 @@
+## Version 2022/02/12
+# In order to use this location block you need to edit the default file one folder up and comment out the / location
+# Homer does not need an base URL set. 
+# The first option assumes you want to run Homer on your domain.tld
+# If you want to run it on domain.tld/homer changing the location /homer should be sufficient.  
+
+location / {
+    # enable the next two lines for http auth
+    #auth_basic "Restricted";
+    #auth_basic_user_file /config/nginx/.htpasswd;
+
+    # enable the next two lines for ldap auth, also customize and enable ldap.conf in the default conf
+    #auth_request /auth;
+    #error_page 401 =200 /ldaplogin;
+
+    # enable for Authelia, also enable authelia-server.conf in the default site config
+    #include /config/nginx/authelia-location.conf;
+
+    include /config/nginx/proxy.conf;
+    include /config/nginx/resolver.conf;
+    set $upstream_app homer;
+    set $upstream_port 8080;
+    set $upstream_proto http;
+    proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+}
+


### PR DESCRIPTION
Added homer subfolder conf.

I have added an simple homer conf to run homer on domain.tld

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	
##  Thanks, team linuxserver.io

