### PR TITLE
Add missing line for authelia authentication

### DIFF
--- a/openhab.subdomain.conf.sample
+++ b/openhab.subdomain.conf.sample
@@ -14,6 +14,9 @@ server {
     # enable for ldap auth, fill in ldap details in ldap.conf
     #include /config/nginx/ldap.conf;
 
+    # enable for Authelia
+    #include /config/nginx/authelia-server.conf;
+
     location / {
         # enable the next two lines for http auth
         #auth_basic "Restricted";


### PR DESCRIPTION
Lines for authelia authentication seems to be missing in the server part of the openhab conf file.
This PR adds the missing line.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

