### PR TITLE
adding headers for guacamole

### DIFF
--- a/calibre.subdomain.conf.sample
+++ b/calibre.subdomain.conf.sample
@@ -37,5 +37,8 @@ server {
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
         proxy_buffering off;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $http_connection;
     }
 }


### PR DESCRIPTION
I setup swag in front of [calibre](https://docs.linuxserver.io/images/docker-calibre) , but it wouldn't show the UI when when I could connect through the reverse proxy. I got it to work after adding these headers which were suggested by the [guacamole docs](https://guacamole.apache.org/doc/0.9.7/gug/proxying-guacamole.html) under the **Proxying Guacamole** section.


