### PR TITLE
Add section for API so companion apps can utilize API

### DIFF
--- a/grocy.subdomain.conf.sample
+++ b/grocy.subdomain.conf.sample
@@ -37,4 +37,17 @@ server {
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
     }
+    
+    location /api {
+        # Needed as a separate endpoint if using Authelia and a
+        # companion application, they cannot work due to the endpoint.
+        # If you do not use a companion app, comment out this API Entry.
+        
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app grocy;
+        set $upstream_port 80;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+    }
 }

--- a/grocy.subdomain.conf.sample
+++ b/grocy.subdomain.conf.sample
@@ -39,10 +39,6 @@ server {
     }
     
     location /api {
-        # Needed as a separate endpoint if using Authelia and a
-        # companion application, they cannot work due to the endpoint.
-        # If you do not use a companion app, comment out this API Entry.
-        
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
         set $upstream_app grocy;


### PR DESCRIPTION
Solves issue related to:
https://discord.com/channels/354974912613449730/506925392603512839/976577147068108820

https://discord.com/channels/354974912613449730/506925392603512839/976578742963019777

Adds an /api section so that companion applications can utilize the API if Authelia is enabled. API cannot be behind authelia as it will fail.