### PR TITLE
Create mattermost.subdomain.conf.sample

### DIFF
--- a/mattermost.subdomain.conf.sample
+++ b/mattermost.subdomain.conf.sample
@@ -1,0 +1,39 @@
+## Version 2022/07/29
+# To learn how to deploy Mattermost via Docker, visit https://docs.mattermost.com/install/install-docker.html
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name mattermost.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    # enable for ldap auth, fill in ldap details in ldap.conf
+    #include /config/nginx/ldap.conf;
+
+    # enable for Authelia
+    #include /config/nginx/authelia-server.conf;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable the next two lines for ldap auth
+        #auth_request /auth;
+        #error_page 401 =200 /ldaplogin;
+
+        # enable for Authelia
+        #include /config/nginx/authelia-location.conf;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app mattermost;
+        set $upstream_port 8065;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+    }
+}


### PR DESCRIPTION
This PR adds a reverse proxy subdomain configuration for a [Mattermost](https://mattermost.com/) instance. To learn how to deploy Mattermost via Docker, visit https://docs.mattermost.com/install/install-docker.html.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

