### PR TITLE
add missing semicolon to monica-subdomain example

### DIFF
--- a/monica.subdomain.conf.sample
+++ b/monica.subdomain.conf.sample
@@ -32,7 +32,7 @@ server {
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
         set $upstream_app monica;
-        set $upstream_port 80
+        set $upstream_port 80;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
     }


### PR DESCRIPTION
Just added a semicolon that was missing the monica subdomain example.  I copied it and used it and it didn't work, so saving anyone else doing the same!