### PR TITLE
Add subdomain conf for apprise-api

### DIFF
--- a/apprise-api.subdomain.conf.sample
+++ b/apprise-api.subdomain.conf.sample
@@ -1,0 +1,41 @@
+## Version 2022/08/16
+# make sure that your dns has a cname set for apprise-api and that your apprise-api container is not using a base url
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name apprise-api.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    # enable for ldap auth, fill in ldap details in ldap.conf
+    #include /config/nginx/ldap.conf;
+
+    # enable for Authelia
+    #include /config/nginx/authelia-server.conf;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable the next two lines for ldap auth
+        #auth_request /auth;
+        #error_page 401 =200 /ldaplogin;
+
+        # enable for Authelia
+        #include /config/nginx/authelia-location.conf;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app apprise-api;
+        set $upstream_port 8000;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    }
+
+}


### PR DESCRIPTION
Added a sample config for apprise-api, tested to work with the [linuxserver/apprise-api](https://docs.linuxserver.io/images/docker-apprise-api) image.
