### PR TITLE
qBittorrent config fixes

### DIFF
--- a/qbittorrent.subdomain.conf.sample
+++ b/qbittorrent.subdomain.conf.sample
@@ -109,4 +109,18 @@ server {
         proxy_set_header Referer '';
         proxy_set_header Host $upstream_app:$upstream_port;
     }
+    
+    location ~ (/qbittorrent)?/scripts {
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app qbittorrent;
+        set $upstream_port 8080;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+        rewrite /qbittorrent(.*) $1 break;
+
+        proxy_set_header Referer '';
+        proxy_set_header Host $upstream_app:$upstream_port;
+    }
 }

--- a/qbittorrent.subfolder.conf.sample
+++ b/qbittorrent.subfolder.conf.sample
@@ -99,3 +99,17 @@ location ^~ /qbittorrent/sync {
     proxy_set_header Referer '';
     proxy_set_header Host $upstream_app:$upstream_port;
 }
+
+location ^~ /qbittorrent/scripts {
+    include /config/nginx/proxy.conf;
+    include /config/nginx/resolver.conf;
+    set $upstream_app qbittorrent;
+    set $upstream_port 8080;
+    set $upstream_proto http;
+    proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    rewrite /qbittorrent(.*) $1 break;
+
+    proxy_set_header Referer '';
+    proxy_set_header Host $upstream_app:$upstream_port;
+}


### PR DESCRIPTION
qBittorrent (v4.4.5) was not loading the log in script from the scripts directory, making the UI not useable (unable to log in). The scripts directory should be included for it to work correctly.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

