### PR TITLE
Instructions for setting Environment variable

### DIFF
--- a/filebrowser.subfolder.conf.sample
+++ b/filebrowser.subfolder.conf.sample
@@ -1,5 +1,5 @@
 ## Version 2022/09/08
-# set this environment variable on your filebrowser container FILEBROWSER_BASEURL=/filebrowser
+# set this environment variable on your filebrowser container FB_BASEURL=/filebrowser
 
 location /filebrowser {
     return 301 $scheme://$host/filebrowser/;

--- a/filebrowser.subfolder.conf.sample
+++ b/filebrowser.subfolder.conf.sample
@@ -1,4 +1,4 @@
-## Version 2022/09/08
+## Version 2022/12/25
 # set this environment variable on your filebrowser container FB_BASEURL=/filebrowser
 
 location /filebrowser {


### PR DESCRIPTION
Line 2 of this file instructs the user to set an environment variable in their filebrowser container, but supplies an incorrect name for that variable.

Filebrowser expects environment variables to be prepended with FB_ as per https://filebrowser.org/cli/filebrowser#options and as mentioned by one of the filebrowser contributors over at https://github.com/filebrowser/filebrowser/issues/1557#issuecomment-921756628

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

