### PR TITLE
Update nextcloud.subdomain.conf.sample

### DIFF
--- a/nextcloud.subdomain.conf.sample
+++ b/nextcloud.subdomain.conf.sample
@@ -32,6 +32,7 @@ server {
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
         proxy_hide_header X-Frame-Options;
+        add_header X-Frame-Options "SAMEORIGIN";
         proxy_max_temp_file_size 2048m;
     }
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
HTTP header is not set to “SAMEORIGIN"

## Benefits of this PR and context
fixe nextcloud warning