### PR TITLE
Add/adjust api and metric endpoints

### DIFF
--- a/authelia.subdomain.conf.sample
+++ b/authelia.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/02/05
+## Version 2023/02/12
 # make sure that your authelia container is named authelia
 # make sure that your dns has a cname set for authelia
 # the default authelia-server and authelia-location confs included with swag rely on
@@ -22,6 +22,30 @@ server {
         include /config/nginx/resolver.conf;
         set $upstream_app authelia;
         set $upstream_port 9091;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    }
+
+    location ~ (/authelia)?/api {
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app authelia;
+        set $upstream_port 9091;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    }
+
+    location ~ (/authelia)?/metrics {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app authelia;
+        set $upstream_port 9959;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 

--- a/authentik.subdomain.conf.sample
+++ b/authentik.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/02/05
+## Version 2023/02/12
 # make sure that your authentik container is named authentik-server
 # make sure that your dns has a cname set for authentik
 
@@ -18,6 +18,30 @@ server {
         include /config/nginx/resolver.conf;
         set $upstream_app authentik-server;
         set $upstream_port 9000;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    }
+
+    location ~ (/authentik)?/api {
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app authentik-server;
+        set $upstream_port 9000;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    }
+
+    location ~ (/authentik)?/metrics {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app authentik-server;
+        set $upstream_port 9300;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 

--- a/flexget.subfolder.conf.sample
+++ b/flexget.subfolder.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/02/05
+## Version 2023/02/12
 # make sure that your flexget container is named flexget
 # make sure that flexget is set to work with the base url /flexget/
 # make sure to set 'base_url: /flexget' under your flexget's config.yml web_server block
@@ -14,12 +14,6 @@ location ^~ /flexget/ {
 
     # enable for ldap auth (requires ldap-server.conf in the server block)
     #include /config/nginx/ldap-location.conf;
-
-    # enable for Authelia (requires authelia-server.conf in the server block)
-    #include /config/nginx/authelia-location.conf;
-
-    # enable for Authentik (requires authentik-server.conf in the server block)
-    #include /config/nginx/authentik-location.conf;
 
     # enable for Authelia (requires authelia-server.conf in the server block)
     #include /config/nginx/authelia-location.conf;

--- a/grafana.subdomain.conf.sample
+++ b/grafana.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/02/05
+## Version 2023/02/12
 # make sure that your grafana container is named grafana
 # make sure that your dns has a cname set for grafana
 
@@ -44,6 +44,30 @@ server {
 
         # Clear Authorization Header if you are using http auth and normal Grafana auth
         #proxy_set_header    Authorization       "";
+
+    }
+
+    location ~ (/grafana)?/api {
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app grafana;
+        set $upstream_port 3000;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    }
+
+    location ~ (/grafana)?/metrics {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app grafana;
+        set $upstream_port 3000;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
     }
 }

--- a/grafana.subfolder.conf.sample
+++ b/grafana.subfolder.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/02/05
+## Version 2023/02/12
 # make sure that your grafana container is named grafana
 # make sure that grafana is set to work with the base url /grafana/
 # grafana requires environment variables set thus:
@@ -19,6 +19,40 @@ location ^~ /grafana/ {
 
     # enable for Authentik (requires authentik-server.conf in the server block)
     #include /config/nginx/authentik-location.conf;
+
+    include /config/nginx/proxy.conf;
+    include /config/nginx/resolver.conf;
+    set $upstream_grafana grafana;
+    set $upstream_port 3000;
+    set $upstream_proto http;
+    proxy_pass http://$upstream_grafana:$upstream_port ;
+
+    # Clear Authorization Header if you are using http auth and normal Grafana auth
+    #proxy_set_header    Authorization       "";
+
+    rewrite ^/grafana/(.*)$ /$1 break;
+
+}
+
+location ^~ /grafana/api {
+    include /config/nginx/proxy.conf;
+    include /config/nginx/resolver.conf;
+    set $upstream_grafana grafana;
+    set $upstream_port 3000;
+    set $upstream_proto http;
+    proxy_pass http://$upstream_grafana:$upstream_port ;
+
+    # Clear Authorization Header if you are using http auth and normal Grafana auth
+    #proxy_set_header    Authorization       "";
+
+    rewrite ^/grafana/(.*)$ /$1 break;
+
+}
+
+location ^~ /grafana/metrics {
+    # enable the next two lines for http auth
+    #auth_basic "Restricted";
+    #auth_basic_user_file /config/nginx/.htpasswd;
 
     include /config/nginx/proxy.conf;
     include /config/nginx/resolver.conf;

--- a/grocy.subdomain.conf.sample
+++ b/grocy.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/02/05
+## Version 2023/02/12
 # make sure that your grocy container is named grocy
 # make sure that your dns has a cname set for grocy
 
@@ -44,7 +44,7 @@ server {
 
     }
 
-    location /api {
+    location ~ (/grocy)?/api {
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
         set $upstream_app grocy;

--- a/overseerr.subdomain.conf.sample
+++ b/overseerr.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/02/05
+## Version 2023/02/12
 # make sure that your overseerr container is named overseerr
 # make sure that your dns has a cname set for overseerr
 
@@ -35,6 +35,16 @@ server {
         # enable for Authentik (requires authentik-server.conf in the server block)
         #include /config/nginx/authentik-location.conf;
 
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app overseerr;
+        set $upstream_port 5055;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    }
+
+    location ~ (/overseerr)?/api {
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
         set $upstream_app overseerr;

--- a/portainer.subdomain.conf.sample
+++ b/portainer.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/02/05
+## Version 2023/02/12
 # make sure that your portainer container is named portainer
 # make sure that your dns has a cname set for portainer
 
@@ -45,20 +45,7 @@ server {
         proxy_hide_header X-Frame-Options; # Possibly not needed after Portainer 1.20.0
     }
 
-    location /api/websocket/ {
-        # enable the next two lines for http auth
-        #auth_basic "Restricted";
-        #auth_basic_user_file /config/nginx/.htpasswd;
-
-        # enable for ldap auth (requires ldap-server.conf in the server block)
-        #include /config/nginx/ldap-location.conf;
-
-        # enable for Authelia (requires authelia-server.conf in the server block)
-        #include /config/nginx/authelia-location.conf;
-
-        # enable for Authentik (requires authentik-server.conf in the server block)
-        #include /config/nginx/authentik-location.conf;
-
+    location ~ (/portainer)?/api {
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
         set $upstream_app portainer;

--- a/portainer.subfolder.conf.sample
+++ b/portainer.subfolder.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/02/05
+## Version 2023/02/12
 # make sure that your portainer container is named portainer
 # portainer does not require a base url setting
 
@@ -31,7 +31,7 @@ location ^~ /portainer/ {
     proxy_hide_header X-Frame-Options; # Possibly not needed after Portainer 1.20.0
 }
 
-location ^~ /portainer/api/websocket/ {
+location ^~ /portainer/api {
     include /config/nginx/proxy.conf;
     include /config/nginx/resolver.conf;
     set $upstream_app portainer;

--- a/prometheus.subdomain.conf.sample
+++ b/prometheus.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/02/05
+## Version 2023/02/12
 # make sure that your prometheus container is named prometheus
 # make sure that your dns has a cname set for prometheus
 
@@ -34,6 +34,44 @@ server {
 
         # enable for Authentik (requires authentik-server.conf in the server block)
         #include /config/nginx/authentik-location.conf;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app prometheus;
+        set $upstream_port 9090;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    }
+
+    location ~ (/prometheus)?/api {
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app prometheus;
+        set $upstream_port 9090;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    }
+
+    location ~ (/prometheus)?/-/(healthy|ready|reload|quit) {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app prometheus;
+        set $upstream_port 9090;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    }
+
+    location ~ (/prometheus)?/metrics {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
 
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;


### PR DESCRIPTION
- Flexget just had duplicated lines (cleaned up)
- Grocy is a superficial change just to match the format in the template
- All the rest are based on the documentation from the application
- I have personally tested/confirmed authelia, authentik, grafana (subdomain), overseerr, portainer (subdomain and subfolder), and prometheus

This closes https://github.com/linuxserver/docker-swag/issues/337