### PR TITLE
Create adminer.subdomain.conf.sample

### DIFF
--- a/adminer.subdomain.conf.sample
+++ b/adminer.subdomain.conf.sample
@@ -1,0 +1,47 @@
+## Version 2023/02/17
+# make sure that your adminer container is named adminer
+# make sure that your dns has a cname set for adminer
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name adminer.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    # enable for ldap auth (requires ldap-location.conf in the location block)
+    #include /config/nginx/ldap-server.conf;
+
+    # enable for Authelia (requires authelia-location.conf in the location block)
+    #include /config/nginx/authelia-server.conf;
+
+    # enable for Authentik (requires authentik-location.conf in the location block)
+    #include /config/nginx/authentik-server.conf;
+
+    location / {
+
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable for ldap auth (requires ldap-server.conf in the server block)
+        #include /config/nginx/ldap-location.conf;
+
+        # enable for Authelia (requires authelia-server.conf in the server block)
+        #include /config/nginx/authelia-location.conf;
+
+        # enable for Authentik (requires authentik-server.conf in the server block)
+        #include /config/nginx/authentik-location.conf;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app adminer;
+        set $upstream_port 8080;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [ ✔️ ] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
<!--- Describe your changes in detail -->
This adds `adminer.subdomain.conf.sample`, based on the template `_template.subdomain.conf.sample`.

## Benefits of this PR and context
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
There is currently only a `adminer.subfolder.conf.sample`, so this should help users who want to run Adminer in a subdomain instead of a subfolder.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've been using this SWAG subdomain configuration for a while now, with Authelia providing authentication and MFA. It's worked great. My Docker setup is running in an Ubuntu VM, using Docker Compose.

## Source / References
<!--- Please include any forum posts/github links relevant to the PR -->
No forum posts or GitHub links, though I asked about this in Discord, in the #dev-talk channel (since there have been a couple of prior PRs for a similar file, but they were not merged). I hope this is useful to someone else!