### PR TITLE
added nexusoss.subdomain.config.sample

### DIFF
--- a/nexusoss.subdomain.conf.sample
+++ b/nexusoss.subdomain.conf.sample
@@ -10,9 +10,6 @@ server {
 
     server_name nexusoss.*;
 
-    # allow large uploads of files - refer to nginx documentation
-    client_max_body_size 1G;
-
     include /config/nginx/ssl.conf;
 
     # enable for ldap auth (requires ldap-location.conf in the location block)
@@ -44,10 +41,6 @@ server {
         set $upstream_port 8081;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
-
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 
     location /v2/ {
@@ -70,9 +63,5 @@ server {
         set $upstream_port 8082;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
-
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 }

--- a/nexusoss.subdomain.conf.sample
+++ b/nexusoss.subdomain.conf.sample
@@ -15,7 +15,29 @@ server {
 
     include /config/nginx/ssl.conf;
 
+    # enable for ldap auth (requires ldap-location.conf in the location block)
+    #include /config/nginx/ldap-server.conf;
+
+    # enable for Authelia (requires authelia-location.conf in the location block)
+    #include /config/nginx/authelia-server.conf;
+
+    # enable for Authentik (requires authentik-location.conf in the location block)
+    #include /config/nginx/authentik-server.conf;
+
     location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable for ldap auth (requires ldap-server.conf in the server block)
+        #include /config/nginx/ldap-location.conf;
+
+        # enable for Authelia (requires authelia-server.conf in the server block)
+        #include /config/nginx/authelia-location.conf;
+
+        # enable for Authentik (requires authentik-server.conf in the server block)
+        #include /config/nginx/authentik-location.conf;
+
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
         set $upstream_app nexusoss;
@@ -29,6 +51,19 @@ server {
     }
 
     location /v2/ {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable for ldap auth (requires ldap-server.conf in the server block)
+        #include /config/nginx/ldap-location.conf;
+
+        # enable for Authelia (requires authelia-server.conf in the server block)
+        #include /config/nginx/authelia-location.conf;
+
+        # enable for Authentik (requires authentik-server.conf in the server block)
+        #include /config/nginx/authentik-location.conf;
+
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
         set $upstream_app nexusoss;

--- a/nexusoss.subdomain.conf.sample
+++ b/nexusoss.subdomain.conf.sample
@@ -1,0 +1,43 @@
+## Version 2023/03/05
+# make sure that your nexusoss container is named nexusoss
+# make sure that your dns has a cname set for nexusoss
+# make sure that the port for the nexusoss container 8081 (the first location "/")
+# make sure that the HTTP Connector port for the hosted docker repository is 8082 (the second location "/v2/")
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name nexusoss.*;
+
+    # allow large uploads of files - refer to nginx documentation
+    client_max_body_size 1G;
+
+    include /config/nginx/ssl.conf;
+
+    location / {
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app nexusoss;
+        set $upstream_port 8081;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location /v2/ {
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app nexusoss;
+        set $upstream_port 8082;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [ ✔️ ] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description
This adds `nexusoss.subdomain.conf.sample` based on the template `_template.subdomain.conf.sample`.

## Benefits of this PR and context
There is currently no sample for nexus3 that I have found, so this should help users to route your nexus3 behind the swag revers-proxy.

## How Has This Been Tested?
I've been using this SWAG subdomain configuration for a while now. SWAG runs on my unraid server and is used to work as reverse-proxy and to optain SSL CERTs. It worked great.

## Source / References
[nexus3 on DockerHub](https://hub.docker.com/r/sonatype/nexus3)
[nexus3 on Github](https://github.com/sonatype/chef-nexus-repository-manager)