### PR TITLE
code-server now requires host header

### DIFF
--- a/code-server.subdomain.conf.sample
+++ b/code-server.subdomain.conf.sample
@@ -41,6 +41,7 @@ server {
         set $upstream_port 8443;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+        proxy_set_header Host $host;
 
     }
 }


### PR DESCRIPTION
2023/03/05

<!--- Provide a general summary of your changes in the Title above -->
code-server now checks origin on web sockets

pass the host header to ensure that check does not fail

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
Forward proxy host header to code-server
<!--- Describe your changes in detail -->

## Benefits of this PR and context
If not passed, code-server will fail to serve web socket content
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

## How Has This Been Tested?
Validated on lab
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Source / References
upstream change:
https://github.com/coder/code-server/commit/be40eca5d92ac2edbd3196e50df1493272431ded
<!--- Please include any forum posts/github links relevant to the PR -->