### PR TITLE
added fenrus and wordpress.subdomain.conf.sample

### DIFF
--- a/fenrus.subdomain.conf.sample
+++ b/fenrus.subdomain.conf.sample
@@ -1,6 +1,6 @@
 ## Version 2023/03/11
 # make sure that your fenrus container is named fenrus
-# make sure that your dns has a cname set for fenrus.example.com
+# make sure that your dns has a cname set for fenrus
 
 server {
     listen 443 ssl;

--- a/fenrus.subdomain.conf.sample
+++ b/fenrus.subdomain.conf.sample
@@ -10,6 +10,8 @@ server {
 
     include /config/nginx/ssl.conf;
 
+    client_max_body_size 0;
+
     # enable for ldap auth (requires ldap-location.conf in the location block)
     #include /config/nginx/ldap-server.conf;
 

--- a/fenrus.subdomain.conf.sample
+++ b/fenrus.subdomain.conf.sample
@@ -1,5 +1,5 @@
 ## Version 2023/03/11
-# make sure that your <container_name> container is named Fenrus
+# make sure that your fenrus container is named fenrus
 # make sure that your dns has a cname set for fenrus.example.com
 
 server {

--- a/fenrus.subdomain.conf.sample
+++ b/fenrus.subdomain.conf.sample
@@ -35,7 +35,7 @@ server {
 
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app Fenrus;
+        set $upstream_app fenrus;
         set $upstream_port 3000;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;

--- a/fenrus.subdomain.conf.sample
+++ b/fenrus.subdomain.conf.sample
@@ -1,0 +1,43 @@
+## Version 2023/03/11
+# make sure that your <container_name> container is named Fenrus
+# make sure that your dns has a cname set for fenrus.example.com
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name fenrus.*;
+
+    include /config/nginx/ssl.conf;
+
+    # enable for ldap auth (requires ldap-location.conf in the location block)
+    #include /config/nginx/ldap-server.conf;
+
+    # enable for Authelia (requires authelia-location.conf in the location block)
+    #include /config/nginx/authelia-server.conf;
+
+    # enable for Authentik (requires authentik-location.conf in the location block)
+    #include /config/nginx/authentik-server.conf;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable for ldap auth (requires ldap-server.conf in the server block)
+        #include /config/nginx/ldap-location.conf;
+
+        # enable for Authelia (requires authelia-server.conf in the server block)
+        #include /config/nginx/authelia-location.conf;
+
+        # enable for Authentik (requires authentik-server.conf in the server block)
+        #include /config/nginx/authentik-location.conf;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app Fenrus;
+        set $upstream_port 3000;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+    }
+}

--- a/nexusoss.subdomain.conf.sample
+++ b/nexusoss.subdomain.conf.sample
@@ -12,6 +12,8 @@ server {
 
     include /config/nginx/ssl.conf;
 
+    client_max_body_size 0;
+
     # enable for ldap auth (requires ldap-location.conf in the location block)
     #include /config/nginx/ldap-server.conf;
 

--- a/wordpress.subdomain.conf.sample
+++ b/wordpress.subdomain.conf.sample
@@ -1,0 +1,44 @@
+## Version 2023/03/12
+# make sure that your wordpress container is named wordpress
+# make sure that your dns has a cname set for wordpress
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name wordpress.*;
+
+    include /config/nginx/ssl.conf;
+
+    # enable for ldap auth (requires ldap-location.conf in the location block)
+    #include /config/nginx/ldap-server.conf;
+
+    # enable for Authelia (requires authelia-location.conf in the location block)
+    #include /config/nginx/authelia-server.conf;
+
+    # enable for Authentik (requires authentik-location.conf in the location block)
+    #include /config/nginx/authentik-server.conf;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable for ldap auth (requires ldap-server.conf in the server block)
+        #include /config/nginx/ldap-location.conf;
+
+        # enable for Authelia (requires authelia-server.conf in the server block)
+        #include /config/nginx/authelia-location.conf;
+
+        # enable for Authentik (requires authentik-server.conf in the server block)
+        #include /config/nginx/authentik-location.conf;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app wordpress;
+        set $upstream_port 80;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    }
+}

--- a/wordpress.subdomain.conf.sample
+++ b/wordpress.subdomain.conf.sample
@@ -10,6 +10,8 @@ server {
 
     include /config/nginx/ssl.conf;
 
+    client_max_body_size 0;
+
     # enable for ldap auth (requires ldap-location.conf in the location block)
     #include /config/nginx/ldap-server.conf;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [✔️ ] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
This adds `fenrus.subdomain.conf.sample` based on the template `_template.subdomain.conf.sample`.
This adds `wordpress.subdomain.conf.sample` based on the template `_template.subdomain.conf.sample`.

## Benefits of this PR and context
I've setup Fenrus Dashboard on my unraid server and run it behind the swag reverse-proxy and now i would like to share the config for other people.

## How Has This Been Tested?
I've been using this SWAG subdomain configuration for a while now. SWAG runs on my unraid server and is used to work as reverse-proxy and to optain SSL CERTs. It worked great.

## Source / References
[fenrus on DockerHub](https://hub.docker.com/r/revenz/fenrus/)
[fenrus on Github](https://github.com/revenz/Fenrus)
[Wordpress](https://wordpress.com/)