### PR TITLE
Create oogway.subdomain.conf.sample

### DIFF
--- a/oogway.subdomain.conf.sample
+++ b/oogway.subdomain.conf.sample
@@ -1,0 +1,48 @@
+## Version 2023/03/16
+# make sure that your oogway container is named oogway
+# Oogway is not usable for subfolder structures
+# https://github.com/emvi/oogway
+
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name oogway.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    # enable for ldap auth (requires ldap-location.conf in the location block)
+    #include /config/nginx/ldap-server.conf;
+
+    # enable for Authelia (requires authelia-location.conf in the location block)
+    #include /config/nginx/authelia-server.conf;
+
+    # enable for Authentik (requires authentik-location.conf in the location block)
+    #include /config/nginx/authentik-server.conf;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable for ldap auth (requires ldap-server.conf in the server block)
+        #include /config/nginx/ldap-location.conf;
+
+        # enable for Authelia (requires authelia-server.conf in the server block)
+        #include /config/nginx/authelia-location.conf;
+
+        # enable for Authentik (requires authentik-server.conf in the server block)
+        #include /config/nginx/authentik-location.conf;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app oogway;
+        set $upstream_port 8080;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    }
+}

--- a/oogway.subdomain.conf.sample
+++ b/oogway.subdomain.conf.sample
@@ -1,7 +1,6 @@
-## Version 2023/03/16
+## Version 2023/04/13
 # make sure that your oogway container is named oogway
-# Oogway is not usable for subfolder structures
-# https://github.com/emvi/oogway
+# make sure that your dns has a cname set for oogway
 
 
 server {


### PR DESCRIPTION
Adding oogway webserver config

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
Adding a new config.sample file for the oogway webserver
<!--- Describe your changes in detail -->

Adding a new possibility
## Benefits of this PR and context
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

Tested with a productive server - subfolder is not supported!
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

https://github.com/emvi/oogway
## Source / References
<!--- Please include any forum posts/github links relevant to the PR -->