### PR TITLE
Vaultwarden: Only match /admin at the start of routes

### DIFF
--- a/vaultwarden.subdomain.conf.sample
+++ b/vaultwarden.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/02/13
+## Version 2023/03/27
 # make sure that your vaultwarden container is named vaultwarden
 # make sure that your dns has a cname set for vaultwarden
 # set the environment variable WEBSOCKET_ENABLED=true on your vaultwarden container

--- a/vaultwarden.subdomain.conf.sample
+++ b/vaultwarden.subdomain.conf.sample
@@ -45,7 +45,7 @@ server {
 
     }
 
-    location ~ (/vaultwarden)?/admin {
+    location ~ ^(/vaultwarden)?/admin {
         # enable the next two lines for http auth
         #auth_basic "Restricted";
         #auth_basic_user_file /config/nginx/.htpasswd;

--- a/vaultwarden.subfolder.conf.sample
+++ b/vaultwarden.subfolder.conf.sample
@@ -31,7 +31,7 @@ location ^~ /vaultwarden/ {
 
 }
 
-location ~ (/vaultwarden)?/admin {
+location ~  ^(/vaultwarden)?/admin {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;

--- a/vaultwarden.subfolder.conf.sample
+++ b/vaultwarden.subfolder.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/02/13
+## Version 2023/03/27
 # make sure that your vaultwarden container is named vaultwarden
 # make sure that vaultwarden is set to work with the base url /vaultwarden/
 ## Environmental Variable DOMAIN=https://<DOMAIN>/vaultwarden must be set in vaultwarden container including subfolder.


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------


## Description

Only match /admin at the start of routes with `^`
Previously, other routes needed for normal operations would also match. Most notably when accessing stuff through the `Organizations` tab of vaultwarden

## Benefits of this PR and context

Allows for guarding of sensitive routes without causing side effects.

## How Has This Been Tested?

Tested with a docker setup running on unraid with vaultwarden and swag containers.

## Source / References

[Motivating issue](https://github.com/dani-garcia/vaultwarden/discussions/3371#discussioncomment-5433139)