### PR TITLE
Adding kavita.subfolder.conf

### DIFF
--- a/kavita.subfolder.conf.sample
+++ b/kavita.subfolder.conf.sample
@@ -2,34 +2,34 @@
 # Make sure you have set base url via Kavita's web gui as /kavita/ and restarted the Kavita.
 
 location /kavita {
-    return 301 $scheme://$host/kavita/;
+	return 301 $scheme://$host/kavita/;
 }
 
 location ^~ /kavita/ {
-    # enable the next two lines for http auth
-    #auth_basic "Restricted";
-    #auth_basic_user_file /config/nginx/.htpasswd;
+	# enable the next two lines for http auth
+	#auth_basic "Restricted";
+	#auth_basic_user_file /config/nginx/.htpasswd;
 
-    # enable for ldap auth (requires ldap-server.conf in the server block)
-    #include /config/nginx/ldap-location.conf;
+	# enable for ldap auth (requires ldap-server.conf in the server block)
+	#include /config/nginx/ldap-location.conf;
 
-    # enable for Authelia (requires authelia-server.conf in the server block)
-    #include /config/nginx/authelia-location.conf;
+	# enable for Authelia (requires authelia-server.conf in the server block)
+	#include /config/nginx/authelia-location.conf;
 
-    include /config/nginx/proxy.conf;
-    include /config/nginx/resolver.conf;
-    set $upstream_app kavita;
-    set $upstream_port 5000 ;
-    set $upstream_proto http;
-    proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+	include /config/nginx/proxy.conf;
+	include /config/nginx/resolver.conf;
+	set $upstream_app kavita;
+	set $upstream_port 5000 ;
+	set $upstream_proto http;
+	proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
 }
 
  location ^~ /kavita/api {
-     include /config/nginx/proxy.conf;
-     include /config/nginx/resolver.conf;
-     set $upstream_app kavita;
-     set $upstream_port 5000;
-     set $upstream_proto http;
-     proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+	 include /config/nginx/proxy.conf;
+	 include /config/nginx/resolver.conf;
+	 set $upstream_app kavita;
+	 set $upstream_port 5000;
+	 set $upstream_proto http;
+	 proxy_pass $upstream_proto://$upstream_app:$upstream_port;
  }

--- a/kavita.subfolder.conf.sample
+++ b/kavita.subfolder.conf.sample
@@ -1,0 +1,35 @@
+## Version 2023/03/27
+# Make sure you have set base url via Kavita's web gui as /kavita/ and restarted the Kavita.
+
+location /kavita {
+    return 301 $scheme://$host/kavita/;
+}
+
+location ^~ /kavita/ {
+    # enable the next two lines for http auth
+    #auth_basic "Restricted";
+    #auth_basic_user_file /config/nginx/.htpasswd;
+
+    # enable for ldap auth (requires ldap-server.conf in the server block)
+    #include /config/nginx/ldap-location.conf;
+
+    # enable for Authelia (requires authelia-server.conf in the server block)
+    #include /config/nginx/authelia-location.conf;
+
+    include /config/nginx/proxy.conf;
+    include /config/nginx/resolver.conf;
+    set $upstream_app kavita;
+    set $upstream_port 5000 ;
+    set $upstream_proto http;
+    proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+}
+
+ location ^~ /kavita/api {
+     include /config/nginx/proxy.conf;
+     include /config/nginx/resolver.conf;
+     set $upstream_app kavita;
+     set $upstream_port 5000;
+     set $upstream_proto http;
+     proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+ }

--- a/kavita.subfolder.conf.sample
+++ b/kavita.subfolder.conf.sample
@@ -1,35 +1,40 @@
-## Version 2023/03/27
-# Make sure you have set base url via Kavita's web gui as /kavita/ and restarted the Kavita.
+## Version 2023/04/13
+# make sure that your kavita container is named kavita
+# make sure that kavita is set to work with the base url /kavita/
 
 location /kavita {
-	return 301 $scheme://$host/kavita/;
+    return 301 $scheme://$host/kavita/;
 }
 
 location ^~ /kavita/ {
-	# enable the next two lines for http auth
-	#auth_basic "Restricted";
-	#auth_basic_user_file /config/nginx/.htpasswd;
+    # enable the next two lines for http auth
+    #auth_basic "Restricted";
+    #auth_basic_user_file /config/nginx/.htpasswd;
 
-	# enable for ldap auth (requires ldap-server.conf in the server block)
-	#include /config/nginx/ldap-location.conf;
+    # enable for ldap auth (requires ldap-server.conf in the server block)
+    #include /config/nginx/ldap-location.conf;
 
-	# enable for Authelia (requires authelia-server.conf in the server block)
-	#include /config/nginx/authelia-location.conf;
+    # enable for Authelia (requires authelia-server.conf in the server block)
+    #include /config/nginx/authelia-location.conf;
 
-	include /config/nginx/proxy.conf;
-	include /config/nginx/resolver.conf;
-	set $upstream_app kavita;
-	set $upstream_port 5000 ;
-	set $upstream_proto http;
-	proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+    # enable for Authentik (requires authentik-server.conf in the server block)
+    #include /config/nginx/authentik-location.conf;
+
+    include /config/nginx/proxy.conf;
+    include /config/nginx/resolver.conf;
+    set $upstream_app kavita;
+    set $upstream_port 5000;
+    set $upstream_proto http;
+    proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
 }
 
- location ^~ /kavita/api {
-	 include /config/nginx/proxy.conf;
-	 include /config/nginx/resolver.conf;
-	 set $upstream_app kavita;
-	 set $upstream_port 5000;
-	 set $upstream_proto http;
-	 proxy_pass $upstream_proto://$upstream_app:$upstream_port;
- }
+location ^~ /kavita/api {
+    include /config/nginx/proxy.conf;
+    include /config/nginx/resolver.conf;
+    set $upstream_app kavita;
+    set $upstream_port 5000;
+    set $upstream_proto http;
+    proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
Added a Kavita subfolder config. Kavita has added Base URL support as of v0.7.1.20.

## Benefits of this PR and context
Adds additional configuration to go along with the subdomain configuration.

## How Has This Been Tested?
I have tested with Kavita nightly version 0.7.1.28 on on my server running Ubuntu 22.04 LTS with Docker v20.10.21.
It works well, unfortunately I use duckdns so I wasn't able to test ssl functionality since duckdns only allows certs on subdomains.
