### PR TITLE
Kasmvnc changes

### DIFF
--- a/boinc.subfolder.conf.sample
+++ b/boinc.subfolder.conf.sample
@@ -30,3 +30,27 @@ location ^~ /boinc/ {
 
     proxy_buffering off;
 }
+
+location ^~ /websockify {
+    # enable the next two lines for http auth
+    #auth_basic "Restricted";
+    #auth_basic_user_file /config/nginx/.htpasswd;
+
+    # enable for ldap auth (requires ldap-server.conf in the server block)
+    #include /config/nginx/ldap-location.conf;
+
+    # enable for Authelia (requires authelia-server.conf in the server block)
+    #include /config/nginx/authelia-location.conf;
+
+    # enable for Authentik (requires authentik-server.conf in the server block)
+    #include /config/nginx/authentik-location.conf;
+
+    include /config/nginx/proxy.conf;
+    include /config/nginx/resolver.conf;
+    set $upstream_app boinc;
+    set $upstream_port 6901;
+    set $upstream_proto http;
+    proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    proxy_buffering          off;
+}

--- a/boinc.subfolder.conf.sample
+++ b/boinc.subfolder.conf.sample
@@ -31,6 +31,10 @@ location ^~ /boinc/ {
     proxy_buffering off;
 }
 
+# If using subfolders for multiple Linux Desktop containers (full gui apps being rendered over web).
+# You will need to modify this path and modify the the client settings in the application.
+# Settings > Advanced > Websocket > Path
+# IE websockify-boinc
 location ^~ /websockify {
     # enable the next two lines for http auth
     #auth_basic "Restricted";

--- a/calibre.subfolder.conf.sample
+++ b/calibre.subfolder.conf.sample
@@ -59,3 +59,27 @@ location ^~ /content-server/ {
     proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
 }
+
+location ^~ /websockify {
+    # enable the next two lines for http auth
+    #auth_basic "Restricted";
+    #auth_basic_user_file /config/nginx/.htpasswd;
+
+    # enable for ldap auth (requires ldap-server.conf in the server block)
+    #include /config/nginx/ldap-location.conf;
+
+    # enable for Authelia (requires authelia-server.conf in the server block)
+    #include /config/nginx/authelia-location.conf;
+
+    # enable for Authentik (requires authentik-server.conf in the server block)
+    #include /config/nginx/authentik-location.conf;
+
+    include /config/nginx/proxy.conf;
+    include /config/nginx/resolver.conf;
+    set $upstream_app calibre;
+    set $upstream_port 6901;
+    set $upstream_proto http;
+    proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    proxy_buffering          off;
+}

--- a/calibre.subfolder.conf.sample
+++ b/calibre.subfolder.conf.sample
@@ -60,6 +60,10 @@ location ^~ /content-server/ {
 
 }
 
+# If using subfolders for multiple Linux Desktop containers (full gui apps being rendered over web).
+# You will need to modify this path and modify the the client settings in the application.
+# Settings > Advanced > Websocket > Path
+# IE websockify-calibre
 location ^~ /websockify {
     # enable the next two lines for http auth
     #auth_basic "Restricted";


### PR DESCRIPTION
This updates the examples for boinc and calibre for the KasmVNC base images to at least function with a subfolder configuration. 

There will be collision if multiple containers with the same KasmVNC base are used, but they can be modified to different paths in the client itself if the user wants to enable multiples, client settings: 

![subfolder](https://user-images.githubusercontent.com/1852688/230990177-aea9ea17-d65c-4acf-93b0-5dcd8f313893.png)

I figured the best support would be to provide a working configuration and deal with 