### PR TITLE
Fix jfa-go conf

### DIFF
--- a/jfa-go.subdomain.conf.sample
+++ b/jfa-go.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/02/05
+## Version 2023/04/16
 # make sure that your jfa-go container is named jfa-go
 # make sure that your dns has a cname set for jfa-go
 
@@ -41,4 +41,6 @@ server {
         set $upstream_port 8056;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
<!--- Describe your changes in detail -->
Important fix for PR #533. Adds a missing `}` sign.

## Benefits of this PR and context
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
A critical fix following PR #533. A missing `}` sign broke jfa-go proxies. I take responsibility for this and wish to fix my mistake with this additional PR.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on the latest release of SWAG, which had the issue.

## Source / References
<!--- Please include any forum posts/github links relevant to the PR -->
- #533