### PR TITLE
check for nginx conf validity

### DIFF
--- a/.github/workflows/check_samples.yml
+++ b/.github/workflows/check_samples.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Check Nginx Conf Validity
         run: |
           curl -fsL "https://raw.githubusercontent.com/linuxserver/docker-swag/master/root/defaults/nginx/proxy.conf.sample" -o proxy.conf
-          docker run -d --rm --name nginx -v "${WORKSPACE}:/testconfs:ro" ghcr.io/linuxserver/nginx
+          docker run -d --rm --name nginx -v "${GITHUB_WORKSPACE}:/testconfs:ro" ghcr.io/linuxserver/nginx
           sleep 5
           docker exec nginx bash -c "\
             mkdir -p /config/nginx/proxy-confs && \

--- a/.github/workflows/check_samples.yml
+++ b/.github/workflows/check_samples.yml
@@ -58,3 +58,24 @@ jobs:
               done
               exit 1
           fi
+
+      - name: Check Nginx Conf Validity
+        run: |
+          curl -fsL "https://raw.githubusercontent.com/linuxserver/docker-swag/master/root/defaults/nginx/proxy.conf.sample" -o proxy.conf
+          docker run -d --rm --name nginx -v "${WORKSPACE}:/testconfs:ro" ghcr.io/linuxserver/nginx
+          sleep 5
+          docker exec nginx bash -c "\
+            mkdir -p /config/nginx/proxy-confs && \
+            cp /testconfs/*.conf.sample /config/nginx/proxy-confs/ && \
+            cp /testconfs/proxy.conf /config/nginx/ && \
+            rm -rf /config/nginx/proxy-confs/{_template.sub*,heimdall.subf*,boinc.subf*,organizr.subf*,wordpress.subf*} && \
+            echo 'include /config/nginx/proxy-confs/*.subdomain.conf.sample;' >> /config/nginx/site-confs/default.conf && \
+            sed -i -r 's|(root \\\$root;)|\1\ninclude /config/nginx/proxy-confs/*.subfolder.conf.sample;|' /config/nginx/site-confs/default.conf"
+          VALIDITY=$(docker exec nginx nginx -t 2>&1) || :
+          echo "${VALIDITY}"
+          echo "${VALIDITY}" >> $GITHUB_STEP_SUMMARY
+          if ! docker exec nginx nginx -t >/dev/null 2>&1; then
+            docker stop nginx
+            exit 1
+          fi
+          docker stop nginx


### PR DESCRIPTION
templates are not valid and are excluded
organizr, heimdall and wordpress subfolder confs duplicate `location /` and thus excluded
boinc subfolder duplicates `location /websockify` with calibre and thus excluded

All other subdomain and subfolder proxy conf samples are added to nginx config on the fly and checked for validity

Successful PR result: https://github.com/linuxserver/reverse-proxy-confs/actions/runs/4714993511
Broken PR result: https://github.com/linuxserver/reverse-proxy-confs/actions/runs/4715002705