### PR TITLE
add kasm subdomain sample

### DIFF
--- a/kasm.subdomain.conf.sample
+++ b/kasm.subdomain.conf.sample
@@ -1,5 +1,6 @@
 ## Version 2023/04/18
 # make sure that your kasm container is named kasm
+# make sure that your dns has a cname set for kasm and kasm-wizard
 
 # This configuration assumes 8443 with the environment variable -e KASM_PORT=8443 set adjust to your needs
 # Post installation you will need to access Kasm > Admin > Zones > default zone (edit) and modify 
@@ -14,7 +15,28 @@ server {
 
     client_max_body_size 0;
 
+    # enable for ldap auth (requires ldap-location.conf in the location block)
+    #include /config/nginx/ldap-server.conf;
+
+    # enable for Authelia (requires authelia-location.conf in the location block)
+    #include /config/nginx/authelia-server.conf;
+
+    # enable for Authentik (requires authentik-location.conf in the location block)
+    #include /config/nginx/authentik-server.conf;
+
     location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable for ldap auth (requires ldap-server.conf in the server block)
+        #include /config/nginx/ldap-location.conf;
+
+        # enable for Authelia (requires authelia-server.conf in the server block)
+        #include /config/nginx/authelia-location.conf;
+
+        # enable for Authentik (requires authentik-server.conf in the server block)
+        #include /config/nginx/authentik-location.conf;
 
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;

--- a/kasm.subdomain.conf.sample
+++ b/kasm.subdomain.conf.sample
@@ -15,17 +15,8 @@ server {
     client_max_body_size 0;
 
     location / {
-        proxy_set_header        Upgrade $http_upgrade;
-        proxy_set_header        Connection "upgrade";
-        proxy_set_header        Host $host;
-        proxy_set_header        X-Real-IP $remote_addr;
-        proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header        X-Forwarded-Proto $scheme;
-        proxy_http_version      1.1;
-        proxy_read_timeout      1800s;
-        proxy_send_timeout      1800s;
-        proxy_connect_timeout   1800s;
-        proxy_buffering         off;
+
+        include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
         set $upstream_app kasm;
         set $upstream_port 8443;

--- a/kasm.subdomain.conf.sample
+++ b/kasm.subdomain.conf.sample
@@ -1,0 +1,80 @@
+# This configuration assumes 8443 with the environment variable -e KASM_PORT=8443 set adjust to your needs
+# Post installation you will need to access Kasm > Admin > Zones > default zone (edit) and modify 
+# Proxy Port to 0 as documented https://www.kasmweb.com/docs/latest/how_to/reverse_proxy.html#update-zones
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name kasm.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    location / {
+        proxy_set_header        Upgrade $http_upgrade;
+        proxy_set_header        Connection "upgrade";
+        proxy_set_header        Host $host;
+        proxy_set_header        X-Real-IP $remote_addr;
+        proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+        proxy_http_version      1.1;
+        proxy_read_timeout      1800s;
+        proxy_send_timeout      1800s;
+        proxy_connect_timeout   1800s;
+        proxy_buffering         off;
+        include /config/nginx/resolver.conf;
+        set $upstream_app kasm;
+        set $upstream_port 8443;
+        set $upstream_proto https;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    }
+
+}
+
+# Wizard UI - Please enable some form of auth if publishing to the internet
+# Or simply remove this and access it locally
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name kasm-wizard.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    # enable for ldap auth (requires ldap-location.conf in the location block)
+    #include /config/nginx/ldap-server.conf;
+
+    # enable for Authelia (requires authelia-location.conf in the location block)
+    #include /config/nginx/authelia-server.conf;
+
+    # enable for Authentik (requires authentik-location.conf in the location block)
+    #include /config/nginx/authentik-server.conf;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable for ldap auth (requires ldap-server.conf in the server block)
+        #include /config/nginx/ldap-location.conf;
+
+        # enable for Authelia (requires authelia-server.conf in the server block)
+        #include /config/nginx/authelia-location.conf;
+
+        # enable for Authentik (requires authentik-server.conf in the server block)
+        #include /config/nginx/authentik-location.conf;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app kasm;
+        set $upstream_port 3000;
+        set $upstream_proto https;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    }
+
+}

--- a/kasm.subdomain.conf.sample
+++ b/kasm.subdomain.conf.sample
@@ -1,3 +1,6 @@
+## Version 2023/04/18
+# make sure that your kasm container is named kasm
+
 # This configuration assumes 8443 with the environment variable -e KASM_PORT=8443 set adjust to your needs
 # Post installation you will need to access Kasm > Admin > Zones > default zone (edit) and modify 
 # Proxy Port to 0 as documented https://www.kasmweb.com/docs/latest/how_to/reverse_proxy.html#update-zones


### PR DESCRIPTION
Adds a subdomain conf for both the main Kasm interface and the wizard with notes about post install configuration. 