### PR TITLE
Add `wizarr.subdomain.conf.sample`

### DIFF
--- a/wizarr.subdomain.conf.sample
+++ b/wizarr.subdomain.conf.sample
@@ -1,0 +1,45 @@
+## Version 2023/02/05
+# make sure that your wizarr container is named wizarr
+# make sure that your dns has a cname set for wizarr
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name wizarr.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    # enable for ldap auth (requires ldap-location.conf in the location block)
+    #include /config/nginx/ldap-server.conf;
+
+    # enable for Authelia (requires authelia-location.conf in the location block)
+    #include /config/nginx/authelia-server.conf;
+
+    # enable for Authentik (requires authentik-location.conf in the location block)
+    #include /config/nginx/authentik-server.conf;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable for ldap auth (requires ldap-server.conf in the server block)
+        #include /config/nginx/ldap-location.conf;
+
+        # enable for Authelia (requires authelia-server.conf in the server block)
+        #include /config/nginx/authelia-location.conf;
+
+        # enable for Authentik (requires authentik-server.conf in the server block)
+        #include /config/nginx/authentik-location.conf;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app wizarr;
+        set $upstream_port 5690;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
Adding a reverse proxy conf for the Plex Invite utility named "[Wizarr](https://github.com/Wizarrrr/wizarr)"

## Benefits of this PR and context
It's a nice tool

## How Has This Been Tested?
Using [this docker-compose.yml](https://docs.wizarr.dev/getting-started/installation) example
Using Docker v5.15.0-70

## Source / References
Wizarr Github: https://github.com/Wizarrrr/wizarr
Wizarr Docs: https://docs.wizarr.dev/getting-started/installation