### PR TITLE
Add `homarr.subdomain.conf.sample`

### DIFF
--- a/homarr.subdomain.conf.sample
+++ b/homarr.subdomain.conf.sample
@@ -1,0 +1,45 @@
+## Version 2023/02/05
+# make sure that your homarr container is named homarr
+# make sure that your dns has a cname set for homarr
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name homarr.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    # enable for ldap auth (requires ldap-location.conf in the location block)
+    #include /config/nginx/ldap-server.conf;
+
+    # enable for Authelia (requires authelia-location.conf in the location block)
+    #include /config/nginx/authelia-server.conf;
+
+    # enable for Authentik (requires authentik-location.conf in the location block)
+    #include /config/nginx/authentik-server.conf;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable for ldap auth (requires ldap-server.conf in the server block)
+        #include /config/nginx/ldap-location.conf;
+
+        # enable for Authelia (requires authelia-server.conf in the server block)
+        #include /config/nginx/authelia-location.conf;
+
+        # enable for Authentik (requires authentik-server.conf in the server block)
+        #include /config/nginx/authentik-location.conf;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app homarr;
+        set $upstream_port 7575;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
Added a reverse proxy conf for the Homarr application/utility/homepage thingy

## Benefits of this PR and context
Yay more Heimdall/Homer alternatives

## How Has This Been Tested?
Tested this successfully with Homarr v0.11
Using Docker 5.15.0-70, with this [docker-compose.yml](https://homarr.dev/docs/introduction/installation#installing) example


## Source / References
Homarr Github:
https://github.com/ajnart/homarr