### PR TITLE
improve documentation for nextcloud security

### DIFF
--- a/nextcloud.subdomain.conf.sample
+++ b/nextcloud.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/02/05
+## Version 2023/05/10
 # make sure that your nextcloud container is named nextcloud
 # make sure that your dns has a cname set for nextcloud
 # assuming this container is called "swag", edit your nextcloud container's config

--- a/nextcloud.subdomain.conf.sample
+++ b/nextcloud.subdomain.conf.sample
@@ -32,6 +32,7 @@ server {
         set $upstream_proto https;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
+        # Uncomment X-Frame-Options directive in ssl.conf to pass security checks.
         proxy_hide_header X-Frame-Options;
         proxy_max_temp_file_size 2048m;
     }

--- a/nextcloud.subfolder.conf.sample
+++ b/nextcloud.subfolder.conf.sample
@@ -34,6 +34,7 @@ location ^~ /nextcloud/ {
     proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
     rewrite /nextcloud(.*) $1 break;
+    # Uncomment X-Frame-Options directive in ssl.conf to pass security checks.
     proxy_hide_header X-Frame-Options;
     proxy_max_temp_file_size 2048m;
     proxy_set_header Range $http_range;

--- a/nextcloud.subfolder.conf.sample
+++ b/nextcloud.subfolder.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/02/05
+## Version 2023/05/10
 # make sure that your nextcloud container is named nextcloud
 # make sure that nextcloud is set to work with the base url /nextcloud/
 # Assuming this container is called "swag", edit your nextcloud container's config


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description
The default configuration does not pass security checks. A change to ssl.conf is required for secure operation. This behaviour can be very confusing to new users. Documenting this should help make it easier for
new nextcloud users to have a secure experience.

## Benefits of this PR and context
The default behavior was very confusing and the correct solution is very non-obvious (change ssl.conf).
A user may simply remove the `proxy_hide_header` directive, which will cause unintended consequences in the future.
closes #569 

## Source / References
#569