### PR TITLE
fix: bypass auth for kavita api endpoint

### DIFF
--- a/kavita.subdomain.conf.sample
+++ b/kavita.subdomain.conf.sample
@@ -43,4 +43,15 @@ server {
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
     }
+
+    # Needed for OPDS access while using Authelia/ldap
+    location ~ /api {
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app kavita;
+        set $upstream_port 5000;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    }
 }

--- a/kavita.subdomain.conf.sample
+++ b/kavita.subdomain.conf.sample
@@ -45,7 +45,7 @@ server {
     }
 
     # Needed for OPDS access while using Authelia/ldap
-    location ~ /api {
+    location ~ (/kavita)?/api {
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
         set $upstream_app kavita;


### PR DESCRIPTION

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------


## Description

Bypass authelia etc for api access to kavita - permits use of OPDS endpoints while auth is in use.

## Benefits of this PR and context

With the current config, when using one of the auth options, access to the OPDS endpoint is captured by nginx & redirected to auth. This adds a bypass for the /api endpoint which uses a token system. 

## How Has This Been Tested?

Implemented the changes on my local system & tested access with Librera on android. Does not work without this change, works with.

## Source / References

Changes taken from Kavita's docs: https://wiki.kavitareader.com/en/install/access-kavita-from-network/reverse-proxy/swag-example