### PR TITLE
Add emby proxy improvements

### DIFF
--- a/emby.subdomain.conf.sample
+++ b/emby.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/02/05
+## Version 2023/05/27
 # make sure that your emby container is named emby
 # make sure that your dns has a cname set for emby
 # if emby is running in bridge mode and the container is named "emby", the below config should work as is
@@ -27,5 +27,27 @@ server {
 
         proxy_set_header Range $http_range;
         proxy_set_header If-Range $http_if_range;
+        
+        gzip on;
+        gzip_disable "msie6";
+        gzip_comp_level 6;
+        gzip_min_length 1100;
+        gzip_buffers 16 8k;
+        gzip_proxied any;
+        gzip_types
+            text/plain
+            text/css
+            text/js
+            text/xml
+            text/javascript
+            application/javascript
+            application/x-javascript
+            application/json
+            application/xml
+            application/rss+xml
+            image/svg+xml;
+            
+        proxy_buffering off;
+        tcp_nodelay on;
     }
 }

--- a/emby.subdomain.conf.sample
+++ b/emby.subdomain.conf.sample
@@ -48,6 +48,5 @@ server {
             image/svg+xml;
             
         proxy_buffering off;
-        tcp_nodelay on;
     }
 }

--- a/emby.subdomain.conf.sample
+++ b/emby.subdomain.conf.sample
@@ -32,7 +32,6 @@ server {
         gzip_disable "msie6";
         gzip_comp_level 6;
         gzip_min_length 1100;
-        gzip_buffers 16 8k;
         gzip_proxied any;
         gzip_types
             text/plain


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
After struggling with emby playback issues on Android devices (using the Android Emby app) for a long time, it seems I finally found the solution in an [older thread on the emby forums](https://emby.media/community/index.php?/topic/84919-reverse-proxy-issues-after-updating-to-4420/).
My issue wasn't exactly the same, since Android playback basically didn't work at all for higher quality (and therefore larger) files.
After starting playback, the server completely stops responding due to high cpu load caused by iowait. (Unfortunately I wasn't able to find out by what exactly this is/was caused.)

Implementing the `proxy_buffering off; ` directive instantly solved this issue.

Also implemented some other recommended directives for using nginx with emby.

## Benefits of this PR and context
Fixes issues with emby playback on Android devices.

## How Has This Been Tested?
Tryed to play movie on an Android device using the existing emby sample config. -> Doesn't work.
Add `proxy_buffering off;` directive and restart swag container.
Try to play the same movie again. -> Works as expected.

The playback issues have been solved by using only the `proxy_buffering off;` directive. The other directives were added mainly because they are recommended in multiple threads on the emby forums. I did not verify if they have any noticable impact whatsoever.

## Source / References
Recommended NGINX config for emby by pir8radio in the emby forums: https://emby.media/community/index.php?/topic/93074-how-to-emby-with-nginx-with-windows-specific-tips-and-csp-options/
Emby forums thread mentioning a similar Android playback issue that lead to the `proxy_buffering off;` directive:
https://emby.media/community/index.php?/topic/84919-reverse-proxy-issues-after-updating-to-4420/