### PR TITLE
Add http2 to all listen directives

### DIFF
--- a/_template.subdomain.conf.sample
+++ b/_template.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # REMOVE THIS LINE BEFORE SUBMITTING: The structure of the file (all of the existing lines) should be kept as close as possible to this template.
 # REMOVE THIS LINE BEFORE SUBMITTING: Look through this file for <tags> and replace them. Review other sample files to see how things are done.
 # REMOVE THIS LINE BEFORE SUBMITTING: The comment lines at the top of the file (below this line) should explain any prerequisites for using the proxy such as DNS or app settings.
@@ -6,8 +6,8 @@
 # make sure that your dns has a cname set for <container_name>
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name <container_name>.*;
 

--- a/adguard.subdomain.conf.sample
+++ b/adguard.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your adguard container is named adguard
 # make sure that your dns has a cname set for adguard
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name adguard.*;
 

--- a/adminer.subdomain.conf.sample
+++ b/adminer.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/17
+## Version 2023/05/31
 # make sure that your adminer container is named adminer
 # make sure that your dns has a cname set for adminer
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name adminer.*;
 

--- a/adminmongo.subdomain.conf.sample
+++ b/adminmongo.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your adminmongo container is named adminmongo
 # make sure that your dns has a cname set for adminmongo
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name adminmongo.*;
 

--- a/airsonic.subdomain.conf.sample
+++ b/airsonic.subdomain.conf.sample
@@ -1,11 +1,11 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your airsonic container is named airsonic
 # make sure that your dns has a cname set for airsonic
 # add `server.use-forward-headers=true` to `/config/application.properties` to ensure logs contain real source IP
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name airsonic.*;
 

--- a/apprise-api.subdomain.conf.sample
+++ b/apprise-api.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your apprise-api container is named apprise-api
 # make sure that your dns has a cname set for apprise-api
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name apprise-api.*;
 

--- a/archisteamfarm.subdomain.conf.sample
+++ b/archisteamfarm.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your archisteamfarm container is named archisteamfarm
 # make sure that your dns has a cname set for archisteamfarm
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name archisteamfarm.*;
 

--- a/aria2-with-webui.subdomain.conf.sample
+++ b/aria2-with-webui.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your aria2 container is named aria2-with-webui
 # make sure that your dns has a cname set for aria2
 #
@@ -7,8 +7,8 @@
 #      https://aria2.example.com/#!/settings/rpc/set?protocol=https&host=aria2.example.com&port=443&interface=aria2-with-webui/jsonrpc
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name aria2.*;
 

--- a/audiobookshelf.subdomain.conf.sample
+++ b/audiobookshelf.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your audiobookshelf container is named audiobookshelf
 # make sure that your dns has a cname set for audiobookshelf
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name audiobookshelf.*;
 

--- a/authelia.subdomain.conf.sample
+++ b/authelia.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/04/29
+## Version 2023/05/31
 # make sure that your authelia container is named authelia
 # make sure that your dns has a cname set for authelia
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name authelia.*;
 

--- a/authentik.subdomain.conf.sample
+++ b/authentik.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/04/14
+## Version 2023/05/31
 # make sure that your authentik container is named authentik-server
 # make sure that your dns has a cname set for authentik
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name authentik.*;
 

--- a/babybuddy.subdomain.conf.sample
+++ b/babybuddy.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your babybuddy container is named babybuddy
 # make sure that your dns has a cname set for babybuddy
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name babybuddy.*;
 

--- a/bazarr.subdomain.conf.sample
+++ b/bazarr.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your bazarr container is named bazarr
 # make sure that your dns has a cname set for bazarr
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name bazarr.*;
 

--- a/beets.subdomain.conf.sample
+++ b/beets.subdomain.conf.sample
@@ -1,11 +1,11 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your beets container is named beets
 # make sure that your dns has a cname set for beets
 #First edit beets.yml and enable the reverse proxy settings, under "web" add "reverse_proxy: true" and restart the beets container.
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name beets.*;
 

--- a/bitwarden.subdomain.conf.sample
+++ b/bitwarden.subdomain.conf.sample
@@ -1,11 +1,11 @@
-## Version 2023/02/13
+## Version 2023/05/31
 # make sure that your bitwarden container is named bitwarden
 # make sure that your dns has a cname set for bitwarden
 # set the environment variable WEBSOCKET_ENABLED=true on your bitwarden container
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name bitwarden.*;
 

--- a/boinc.subdomain.conf.sample
+++ b/boinc.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your boinc container is named boinc
 # make sure that your dns has a cname set for boinc
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name boinc.*;
 

--- a/booksonic.subdomain.conf.sample
+++ b/booksonic.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your booksonic container is named booksonic
 # make sure that your dns has a cname set for booksonic
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name booksonic.*;
 

--- a/bookstack.subdomain.conf.sample
+++ b/bookstack.subdomain.conf.sample
@@ -1,12 +1,12 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your bookstack container is named bookstack
 # make sure that your dns has a cname set for bookstack
 # Ensure you have the APP_URL Environment Variable set correctly in your Docker Run/Compose or in BookStack Env File (/www/.env)
 # https://github.com/linuxserver/docker-bookstack#docker
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name bookstack.*;
 

--- a/budge.subdomain.conf.sample
+++ b/budge.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your budge container is named budge
 # make sure that your dns has a cname set for budge
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name budge.*;
 

--- a/cadvisor.subdomain.conf.sample
+++ b/cadvisor.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/03/25
+## Version 2023/05/31
 # make sure that your cadvisor container is named cadvisor
 # make sure that your dns has a cname set for cadvisor
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name cadvisor.*;
 

--- a/calibre-web.subdomain.conf.sample
+++ b/calibre-web.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your calibre-web container is named calibre-web
 # make sure that your dns has a cname set for calibre-web
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name calibre-web.*;
 

--- a/calibre.subdomain.conf.sample
+++ b/calibre.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your calibre container is named calibre
 # make sure that your dns has a cname set for calibre
 # for the content server, go into calibre preferences / sharing over the net / advanced and
@@ -6,8 +6,8 @@
 # the content server will be accessible at 'https://calibre.domain.com/content-server/'
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name calibre.*;
 

--- a/castopod.subdomain.conf.sample
+++ b/castopod.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your castopod container is named castopod
 # make sure that your dns has a cname set for castopod
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name castopod.*;
 

--- a/changedetection.subdomain.conf.sample
+++ b/changedetection.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your changedetection container is named changedetection
 # make sure that your dns has a cname set for changedetection
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name changedetection.*;
 

--- a/chevereto.subdomain.conf.sample
+++ b/chevereto.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your chevereto container is named chevereto
 # make sure that your dns has a cname set for chevereto
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name chevereto.*;
 

--- a/chronograf.subdomain.conf.sample
+++ b/chronograf.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your chronograf container is named chronograf
 # make sure that your dns has a cname set for chronograf
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name chronograf.*;
 

--- a/cloudbeaver.subdomain.conf.sample
+++ b/cloudbeaver.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your cloudbeaver container is named cloudbeaver
 # make sure that your dns has a cname set for cloudbeaver
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name cloudbeaver.*;
 

--- a/code-server.subdomain.conf.sample
+++ b/code-server.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your code-server container is named code-server
 # make sure that your dns has a cname set for code-server
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name code-server.* "~^[0-9]{1,10}\.code-server\..*$";
 

--- a/codimd.subdomain.conf.sample
+++ b/codimd.subdomain.conf.sample
@@ -1,11 +1,11 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure you have added the following environmental variables to your run command/compose file
 # CMD_DOMAIN=codimd.server.com
 # CMD_PROTOCOL_USESSL=true
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name codimd.*;
 

--- a/collabora.subdomain.conf.sample
+++ b/collabora.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your collabora container is named collabora
 # make sure that your dns has a cname set for collabora
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name collabora.*;
 

--- a/commento.subdomain.conf.sample
+++ b/commento.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your commento container is named commento
 # make sure that your dns has a cname set for commento
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name commento.*;
 

--- a/couchpotato.subdomain.conf.sample
+++ b/couchpotato.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your couchpotato container is named couchpotato
 # make sure that your dns has a cname set for couchpotato
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name couchpotato.*;
 

--- a/crowdsec-dashboard.subdomain.conf.sample
+++ b/crowdsec-dashboard.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your crowdsec-dashboard container is named crowdsec-dashboard
 # make sure that your dns has a cname set for crowdsec-dashboard
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name crowdsec-dashboard.*;
 

--- a/crowdsec.subdomain.conf.sample
+++ b/crowdsec.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your crowdsec container is named crowdsec
 # make sure that your dns has a cname set for crowdsec
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name crowdsec.*;
 

--- a/dashy.subdomain.conf.sample
+++ b/dashy.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your dashy container is named dashy
 # make sure that your dns has a cname set for dashy
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name dashy.*;
 

--- a/deluge.subdomain.conf.sample
+++ b/deluge.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your deluge container is named deluge
 # make sure that your dns has a cname set for deluge
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name deluge.*;
 

--- a/dillinger.subdomain.conf.sample
+++ b/dillinger.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your dillinger container is named dillinger
 # make sure that your dns has a cname set for dillinger
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name dillinger.*;
 

--- a/documentserver.subdomain.conf.sample
+++ b/documentserver.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your onlyoffice documentserver container is named documentserver
 # make sure that your dns has a cname set for documentserver
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name documentserver.*;
 

--- a/dokuwiki.subdomain.conf.sample
+++ b/dokuwiki.subdomain.conf.sample
@@ -1,11 +1,11 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your dokuwiki container is named dokuwiki
 # make sure that your dns has a cname set for dokuwiki
 # complete the setup by appending install.php to URL
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name dokuwiki.*;
 

--- a/domoticz.subdomain.conf.sample
+++ b/domoticz.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your domoticz container is named domoticz
 # make sure that your dns has a cname set for domoticz
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name domoticz.*;
 

--- a/dozzle.subdomain.conf.sample
+++ b/dozzle.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your dozzle container is named dozzle
 # make sure that your dns has a cname set for dozzle
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name dozzle.*;
 

--- a/drone.subdomain.conf.sample
+++ b/drone.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your drone container is named drone
 # make sure that your dns has a cname set for drone
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name drone.*;
 

--- a/dsmrreader.subdomain.conf.sample
+++ b/dsmrreader.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your dsmr container is named dsmr
 # make sure that your dns has a cname set for dsmr
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name dsmr.*;
 

--- a/duplicacy.subdomain.conf.sample
+++ b/duplicacy.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/04/13
+## Version 2023/05/31
 # make sure that your duplicacy container is named duplicacy
 # make sure that your dns has a cname set for duplicacy
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name duplicacy.*;
 

--- a/duplicati.subdomain.conf.sample
+++ b/duplicati.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your duplicati container is named duplicati
 # make sure that your dns has a cname set for duplicati
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name duplicati.*;
 

--- a/emby.subdomain.conf.sample
+++ b/emby.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your emby container is named emby
 # make sure that your dns has a cname set for emby
 # if emby is running in bridge mode and the container is named "emby", the below config should work as is
@@ -8,8 +8,8 @@
 # and set the "Secure connection mode" to "Handled by reverse proxy"
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name emby.*;
 

--- a/embystat.subdomain.conf.sample
+++ b/embystat.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your embystat container is named embystat
 # make sure that your dns has a cname set for embystat
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name embystat.*;
 

--- a/emulatorjs.subdomain.conf.sample
+++ b/emulatorjs.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your emulatorjs container is named emulatorjs
 # make sure that your dns has a cname set for emulatorjs
 # In emulatorjs docker arguments, set an env variable for SUBFOLDER=/backend/
@@ -6,8 +6,8 @@
 # Don't forget to enable auth at least for the /backend/ location
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name emulatorjs.*;
 

--- a/esphome.subdomain.conf.sample
+++ b/esphome.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your esphome container is named esphome
 # make sure that your dns has a cname set for esphome
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name esphome.*;
 

--- a/fenrus.subdomain.conf.sample
+++ b/fenrus.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/03/11
+## Version 2023/05/31
 # make sure that your fenrus container is named fenrus
 # make sure that your dns has a cname set for fenrus
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name fenrus.*;
 

--- a/filebot.subdomain.conf.sample
+++ b/filebot.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your filebot container is named filebot
 # make sure that your dns has a cname set for filebot
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name filebot.*;
 

--- a/filebrowser.subdomain.conf.sample
+++ b/filebrowser.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your filebrowser container is named filebrowser
 # make sure that your dns has a cname set for filebrowser
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name filebrowser.*;
 

--- a/firefly.subdomain.conf.sample
+++ b/firefly.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your firefly container is named firefly
 # make sure that your dns has a cname set for firefly
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name firefly.*;
 

--- a/firefox.subdomain.conf.sample
+++ b/firefox.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your firefox container is named firefox
 # make sure that your dns has a cname set for firefox
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name firefox.*;
 

--- a/flexget.subdomain.conf.sample
+++ b/flexget.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your flexget container is named flexget
 # make sure that your dns has a cname set for flexget
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name flexget.*;
 

--- a/flood.subdomain.conf.sample
+++ b/flood.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your flood container is named flood
 # make sure that your dns has a cname set for flood
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name flood.*;
 

--- a/foldingathome.subdomain.conf.sample
+++ b/foldingathome.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your foldingathome container is named foldingathome
 # make sure that your dns has a cname set for foldingathome
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name foldingathome.*;
 

--- a/foundryvtt.subdomain.conf.sample
+++ b/foundryvtt.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your foundryvtt container is named foundryvtt
 # make sure that your dns has a cname set for foundryvtt
 # Ensure that your Foundry VTT's {userData}/Config/options.json file is configured as follows:
@@ -12,8 +12,8 @@
 # Refer to https://foundryvtt.com/article/nginx/ for the latest Foundry configuration information
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name foundryvtt.*;
 

--- a/freshrss.subdomain.conf.sample
+++ b/freshrss.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your freshrss container is named freshrss
 # make sure that your dns has a cname set for freshrss
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name freshrss.*;
 

--- a/gaps.subdomain.conf.sample
+++ b/gaps.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your gaps container is named gaps
 # make sure that your dns has a cname set for gaps
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name gaps.*;
 

--- a/get_iplayer.subdomain.conf.sample
+++ b/get_iplayer.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your get_iplayer container is named get_iplayer
 # make sure that your dns has a cname set for get_iplayer
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name get_iplayer.*;
 

--- a/ghost.subdomain.conf.sample
+++ b/ghost.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your ghost container is named ghost
 # make sure that your dns has a cname set for ghost
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name ghost.*;
 

--- a/gitea.subdomain.conf.sample
+++ b/gitea.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your gitea container is named gitea
 # make sure that your dns has a cname set for gitea
 # edit the following parameters in /data/gitea/conf/app.ini
@@ -8,8 +8,8 @@
 # DOMAIN           = gitea.server.com
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name gitea.*;
 

--- a/glances.subdomain.conf.sample
+++ b/glances.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your glances container is named glances
 # make sure that your dns has a cname set for glances
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name glances.*;
 

--- a/gotify.subdomain.conf.sample
+++ b/gotify.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your gotify container is named gotify
 # make sure that your dns has a cname set for gotify
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name gotify.*;
 

--- a/grafana.subdomain.conf.sample
+++ b/grafana.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/04/20
+## Version 2023/05/31
 # make sure that your grafana container is named grafana
 # make sure that your dns has a cname set for grafana
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name grafana.*;
 

--- a/grav.subdomain.conf.sample
+++ b/grav.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/03/17
+## Version 2023/05/31
 # make sure that your grav container is named grav
 # make sure that your dns has a cname set for grav
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name grav.*;
 

--- a/graylog.subdomain.conf.sample
+++ b/graylog.subdomain.conf.sample
@@ -1,12 +1,12 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your graylog container is named graylog
 # make sure that your dns has a cname set for graylog
 # Ensure the upstream_port matches your GRAYLOG_HTTP_BIND_ADDRESS port
 # This conf assumes GRAYLOG_HTTP_BIND_ADDRESS=0.0.0.0:9000
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name graylog.*;
 

--- a/grocy.subdomain.conf.sample
+++ b/grocy.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/12
+## Version 2023/05/31
 # make sure that your grocy container is named grocy
 # make sure that your dns has a cname set for grocy
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name grocy.*;
 

--- a/guacamole.subdomain.conf.sample
+++ b/guacamole.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your guacamole container is named guacamole
 # make sure that your dns has a cname set for guacamole
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name guacamole.*;
 

--- a/hass-configurator.subdomain.conf.sample
+++ b/hass-configurator.subdomain.conf.sample
@@ -1,12 +1,12 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your hass container is named hass
 # make sure that your dns has a cname set for hass
 # this proxy configuration file is for the hass-configurator-docker container that is used
 # in the hassos addon store (https://github.com/CausticLab/hass-configurator-docker)
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name hass-configurator.*;
 

--- a/headphones.subdomain.conf.sample
+++ b/headphones.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your headphones container is named headphones
 # make sure that your dns has a cname set for headphones
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name headphones.*;
 

--- a/healthchecks.subdomain.conf.sample
+++ b/healthchecks.subdomain.conf.sample
@@ -1,11 +1,11 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your healthchecks container is named healthchecks
 # make sure that your dns has a cname set for healthchecks
 # make sure your Healthchecks ALLOWED_HOSTS and SITE_ROOT align with the server_name used in this conf.
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name healthchecks.*;
 

--- a/hedgedoc.subdomain.conf.sample
+++ b/hedgedoc.subdomain.conf.sample
@@ -1,12 +1,12 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure you set the following environment variables in your docker arguments
 # CMD_DOMAIN=hedgedoc.server.com
 # CMD_URL_ADDPORT=false
 # CMD_PROTOCOL_USESSL=true
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name hedgedoc.*;
 

--- a/heimdall.subdomain.conf.sample
+++ b/heimdall.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your heimdall container is named heimdall
 # make sure that your dns has a cname set for heimdall
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name heimdall.*;
 

--- a/homarr.subdomain.conf.sample
+++ b/homarr.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your homarr container is named homarr
 # make sure that your dns has a cname set for homarr
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name homarr.*;
 

--- a/homeassistant.subdomain.conf.sample
+++ b/homeassistant.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your homeassistant container is named homeassistant
 # make sure that your dns has a cname set for homeassistant
 
@@ -12,8 +12,8 @@
 #     - 172.16.0.0/12
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name homeassistant.*;
 

--- a/homebridge.subdomain.conf.sample
+++ b/homebridge.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your homebridge container is named homebridge
 # make sure that your dns has a cname set for homebridge
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name homebridge.*;
 

--- a/homer.subdomain.conf.sample
+++ b/homer.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your homer container is named homer
 # make sure that your dns has a cname set for homer
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name homer.*;
 

--- a/huginn.subdomain.conf.sample
+++ b/huginn.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your huginn container is named huginn
 # make sure that your dns has a cname set for huginn
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name huginn.*;
 

--- a/influxdb.subdomain.conf.sample
+++ b/influxdb.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your influxdb container is named influxdb
 # make sure that your dns has a cname set for influxdb
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name influxdb.*;
 

--- a/it-tools.subdomain.conf.sample
+++ b/it-tools.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/05/08
+## Version 2023/05/31
 # make sure that your it-tools container is named it-tools
 # make sure that your dns has a cname set for it-tools
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name it-tools.*;
 

--- a/jackett.subdomain.conf.sample
+++ b/jackett.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your jackett container is named jackett
 # make sure that your dns has a cname set for jackett
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name jackett.*;
 

--- a/jdownloader.subdomain.conf.sample
+++ b/jdownloader.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your jdownloader container is named jdownloader
 # make sure that your dns has a cname set for jdownloader
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name jdownloader.*;
 

--- a/jellyfin.subdomain.conf.sample
+++ b/jellyfin.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your jellyfin container is named jellyfin
 # make sure that your dns has a cname set for jellyfin
 # if jellyfin is running in bridge mode and the container is named "jellyfin", the below config should work as is
@@ -7,8 +7,8 @@
 # in jellyfin settings, under "Advanced/Networking" add subdomain.mydomain.tld as a known proxy
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name jellyfin.*;
 

--- a/jellyseerr.subdomain.conf.sample
+++ b/jellyseerr.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your jellyseerr container is named jellyseerr
 # make sure that your dns has a cname set for jellyseerr
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name jellyseerr.*;
 

--- a/jfa-go.subdomain.conf.sample
+++ b/jfa-go.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/04/16
+## Version 2023/05/31
 # make sure that your jfa-go container is named jfa-go
 # make sure that your dns has a cname set for jfa-go
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name jfa-go.*;
 

--- a/kanzi.subdomain.conf.sample
+++ b/kanzi.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your kanzi container is named kanzi
 # make sure that your dns has a cname set for kanzi
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name kanzi.*;
 

--- a/kasm.subdomain.conf.sample
+++ b/kasm.subdomain.conf.sample
@@ -1,13 +1,13 @@
-## Version 2023/04/18
+## Version 2023/05/31
 # make sure that your kasm container is named kasm
 # make sure that your dns has a cname set for kasm and kasm-wizard
 
 # This configuration assumes 8443 with the environment variable -e KASM_PORT=8443 set adjust to your needs
-# Post installation you will need to access Kasm > Admin > Zones > default zone (edit) and modify 
+# Post installation you will need to access Kasm > Admin > Zones > default zone (edit) and modify
 # Proxy Port to 0 as documented https://www.kasmweb.com/docs/latest/how_to/reverse_proxy.html#update-zones
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name kasm.*;
 
@@ -52,8 +52,8 @@ server {
 # Wizard UI - Please enable some form of auth if publishing to the internet
 # Or simply remove this and access it locally
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name kasm-wizard.*;
 

--- a/kavita.subdomain.conf.sample
+++ b/kavita.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your kavita container is named kavita
 # make sure that your dns has a cname set for kavita
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name kavita.*;
 

--- a/komga.subdomain.conf.sample
+++ b/komga.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your komga container is named komga
 # make sure that your dns has a cname set for komga
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name komga.*;
 

--- a/lazylibrarian.subdomain.conf.sample
+++ b/lazylibrarian.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your lazylibrarian container is named lazylibrarian
 # make sure that your dns has a cname set for lazylibrarian
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name lazylibrarian.*;
 

--- a/leantime.subdomain.conf.sample
+++ b/leantime.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/19
+## Version 2023/05/31
 # make sure that your leantime container is named leantime
 # make sure that your dns has a cname set for leantime
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name leantime.*;
 

--- a/librespeed.subdomain.conf.sample
+++ b/librespeed.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your librespeed container is named librespeed
 # make sure that your dns has a cname set for librespeed
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name librespeed.*;
 

--- a/lidarr.subdomain.conf.sample
+++ b/lidarr.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your lidarr container is named lidarr
 # make sure that your dns has a cname set for lidarr
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name lidarr.*;
 

--- a/lldap.subdomain.conf.sample
+++ b/lldap.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your lldap container is named lldap
 # make sure that your dns has a cname set for lldap
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name lldap.*;
 

--- a/lychee.subdomain.conf.sample
+++ b/lychee.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your lychee container is named lychee
 # make sure that your dns has a cname set for lychee
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name lychee.*;
 

--- a/mailu.subdomain.conf.sample
+++ b/mailu.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your mailu container is named front
 # make sure that your dns has a cname set for mailu
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name mailu.*;
 

--- a/mastodon.subdomain.conf.sample
+++ b/mastodon.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your mastodon container is named mastodon
 # make sure that your dns has a cname set for mastodon
 # make sure you set `WEB_DOMAIN=mastodon.example.com` env var for the mastodon container
@@ -7,8 +7,8 @@
 # See the upstream docs for more info: https://docs.joinmastodon.org/admin/config/#basic
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name mastodon.*;
 

--- a/matomo.subdomain.conf.sample
+++ b/matomo.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your matomo container is named matomo
 # make sure that your dns has a cname set for matomo
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name matomo.*;
 

--- a/mattermost.subdomain.conf.sample
+++ b/mattermost.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # Make sure that your DNS has a CNAME record for "mattermost" and your Mattermost container is using the same subdomain
 # To learn how to deploy Mattermost via Docker, visit https://docs.mattermost.com/install/install-docker.html
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name mattermost.*;
 

--- a/mealie.subdomain.conf.sample
+++ b/mealie.subdomain.conf.sample
@@ -1,9 +1,9 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # Ensure your DNS has a CNAME set for mealie and that mealie container is named.
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name mealie.*;
 

--- a/medusa.subdomain.conf.sample
+++ b/medusa.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your medusa container is named medusa
 # make sure that your dns has a cname set for medusa
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name medusa.*;
 

--- a/metube.subdomain.conf.sample
+++ b/metube.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your metube container is named metube
 # make sure that your dns has a cname set for metube
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name metube.*;
 

--- a/miniflux.subdomain.conf.sample
+++ b/miniflux.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your miniflux container is named miniflux
 # make sure that your dns has a cname set for miniflux
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name miniflux.*;
 

--- a/monica.subdomain.conf.sample
+++ b/monica.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your monica. container is named monica.
 # make sure that your dns has a cname set for monica.
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name monica.*;
 

--- a/monitorr.subdomain.conf.sample
+++ b/monitorr.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your monitorr container is named monitorr
 # make sure that your dns has a cname set for monitorr
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name monitorr.*;
 

--- a/mstream.subdomain.conf.sample
+++ b/mstream.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your mstream container is named mstream
 # make sure that your dns has a cname set for mstream
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name mstream.*;
 

--- a/mylar.subdomain.conf.sample
+++ b/mylar.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your mylar container is named mylar
 # make sure that your dns has a cname set for mylar
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name mylar.*;
 

--- a/n8n.subdomain.conf.sample
+++ b/n8n.subdomain.conf.sample
@@ -1,11 +1,11 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your n8n container is named n8n
 # make sure that your dns has a cname set for n8n
 # add `server.use-forward-headers=true` to `/config/application.properties` to ensure logs contain real source IP
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name n8n.*;
 

--- a/navidrome.subdomain.conf.sample
+++ b/navidrome.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your navidrome container is named navidrome
 # make sure that your dns has a cname set for navidrome
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name navidrome.*;
 

--- a/netboot.subdomain.conf.sample
+++ b/netboot.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your netboot container is named netboot
 # make sure that your dns has a cname set for netboot
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name netboot.*;
 

--- a/netbox.subdomain.conf.sample
+++ b/netbox.subdomain.conf.sample
@@ -1,12 +1,12 @@
-## Version 2023/02/17
+## Version 2023/05/31
 # make sure that your container is named netbox
 # make sure that your dns has a cname set for netbox
 # make sure your netbox instance is using ALLOWED_HOST=netbox.domain.com (replace with your own domain)
 # or edit both the environment variable and this conf file if using a different subdomain
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name netbox.*;
 

--- a/netdata.subdomain.conf.sample
+++ b/netdata.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your netdata container is named netdata
 # make sure that your dns has a cname set for netdata
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name netdata.*;
 

--- a/nextcloud.subdomain.conf.sample
+++ b/nextcloud.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/05/10
+## Version 2023/05/31
 # make sure that your nextcloud container is named nextcloud
 # make sure that your dns has a cname set for nextcloud
 # assuming this container is called "swag", edit your nextcloud container's config
@@ -15,8 +15,8 @@
 #  ),
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name nextcloud.*;
 

--- a/nexusoss.subdomain.conf.sample
+++ b/nexusoss.subdomain.conf.sample
@@ -1,12 +1,12 @@
-## Version 2023/03/05
+## Version 2023/05/31
 # make sure that your nexusoss container is named nexusoss
 # make sure that your dns has a cname set for nexusoss
 # make sure that the port for the nexusoss container 8081 (the first location "/")
 # make sure that the HTTP Connector port for the hosted docker repository is 8082 (the second location "/v2/")
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name nexusoss.*;
 

--- a/notifiarr.subdomain.conf.sample
+++ b/notifiarr.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your notifiarr container is named notifiarr
 # make sure that your dns has a cname set for notifiarr
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name notifiarr.*;
 

--- a/ntfy.subdomain.conf.sample
+++ b/ntfy.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your ntfy container is named ntfy
 # make sure that your dns has a cname set for ntfy
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name ntfy.*;
 

--- a/nzbget.subdomain.conf.sample
+++ b/nzbget.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your nzbget container is named nzbget
 # make sure that your dns has a cname set for nzbget
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name nzbget.*;
 

--- a/nzbhydra.subdomain.conf.sample
+++ b/nzbhydra.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your nzbhydra container is named nzbhydra2
 # make sure that your dns has a cname set for nzbhydra
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name nzbhydra.*;
 

--- a/octoprint.subdomain.conf.sample
+++ b/octoprint.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your octoprint container is named octoprint
 # make sure that your dns has a cname set for octoprint
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name octoprint.*;
 

--- a/ombi.subdomain.conf.sample
+++ b/ombi.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your ombi container is named ombi
 # make sure that your dns has a cname set for ombi
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name ombi.*;
 

--- a/oogway.subdomain.conf.sample
+++ b/oogway.subdomain.conf.sample
@@ -1,11 +1,11 @@
-## Version 2023/04/13
+## Version 2023/05/31
 # make sure that your oogway container is named oogway
 # make sure that your dns has a cname set for oogway
 
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name oogway.*;
 

--- a/openhab.subdomain.conf.sample
+++ b/openhab.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your openhab container is named openhab
 # make sure that your dns has a cname set for openhab
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name openhab.*;
 

--- a/openvpn-as.subdomain.conf.sample
+++ b/openvpn-as.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your openvpn-as container is named openvpn-as
 # make sure that your dns has a cname set for openvpn-as
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name openvpn-as.*;
 

--- a/openvscode-server.subdomain.conf.sample
+++ b/openvscode-server.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your openvscode-server container is named openvscode-server
 # make sure that your dns has a cname set for openvscode-server
 # This conf allows accessing internal ports at `PORT` (http) or `PORTs` (https) as subdomain
@@ -6,8 +6,8 @@
 # Access https port 8080 at `https://8080s.openvscode-server.domain.url`
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name openvscode-server.*;
 
@@ -49,8 +49,8 @@ server {
 }
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name "~^(?<upstream_port>[0-9]{1,10})\.openvscode-server\..*$";
 
@@ -91,8 +91,8 @@ server {
 }
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name "~^(?<upstream_port>[0-9]{1,10})s\.openvscode-server\..*$";
 

--- a/organizr.subdomain.conf.sample
+++ b/organizr.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your organizr container is named organizr
 # make sure that your dns has a cname set for organizr
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name organizr.*;
 

--- a/osticket.subdomain.conf.sample
+++ b/osticket.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your osticket container is named osticket
 # make sure that your dns has a cname set for osticket
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name osticket.*;
 

--- a/overseerr.subdomain.conf.sample
+++ b/overseerr.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/12
+## Version 2023/05/31
 # make sure that your overseerr container is named overseerr
 # make sure that your dns has a cname set for overseerr
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name overseerr.*;
 

--- a/papermerge.subdomain.conf.sample
+++ b/papermerge.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your papermerge container is named papermerge
 # make sure that your dns has a cname set for papermerge
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name papermerge.*;
 

--- a/petio.subdomain.conf.sample
+++ b/petio.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your petio container is named petio
 # make sure that your dns has a cname set for petio
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name petio.*;
 

--- a/pgadmin.subdomain.conf.sample
+++ b/pgadmin.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/10
+## Version 2023/05/31
 # make sure that your pgadmin container is named pgadmin
 # make sure that your dns has a cname set for pgadmin
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name pgadmin.*;
 

--- a/photoprism.subdomain.conf.sample
+++ b/photoprism.subdomain.conf.sample
@@ -1,9 +1,9 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # Ensure your DNS has a CNAME set for Photoprism and that Photoprism container is named.
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name photoprism.*;
 

--- a/phpmyadmin.subdomain.conf.sample
+++ b/phpmyadmin.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your phpmyadmin container is named phpmyadmin
 # make sure that your dns has a cname set for phpmyadmin
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name phpmyadmin.*;
 

--- a/pihole.subdomain.conf.sample
+++ b/pihole.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your pihole container is named pihole
 # make sure that your dns has a cname set for pihole
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name pihole.*;
 

--- a/pinry.subdomain.conf.sample
+++ b/pinry.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your pinry container is named pinry
 # make sure that your dns has a cname set for pinry
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name pinry.*;
 

--- a/piwigo.subdomain.conf.sample
+++ b/piwigo.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your piwigo container is named piwigo
 # make sure that your dns has a cname set for piwigo
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name piwigo.*;
 

--- a/pixelfed.subdomain.conf.sample
+++ b/pixelfed.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your pixelfed container is named pixelfed
 # make sure that your dns has a cname set for pixelfed
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name pixelfed.*;
 

--- a/planka.subdomain.conf.sample
+++ b/planka.subdomain.conf.sample
@@ -1,11 +1,11 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your planka container is named planka
 # make sure that your dns has a cname set for planka
 # make sure that the BASE_URL env variable in planka container is set to: BASE_URL="https://planka.example.com"
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name planka.*;
 

--- a/plex.subdomain.conf.sample
+++ b/plex.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your plex container is named plex
 # make sure that your dns has a cname set for plex
 # if plex is running in bridge mode and the container is named "plex", the below config should work as is
@@ -7,8 +7,8 @@
 # in plex server settings, under network, fill in "Custom server access URLs" with your domain (ie. "https://plex.yourdomain.url:443")
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name plex.*;
 

--- a/plexwebtools.subdomain.conf.sample
+++ b/plexwebtools.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your plex container is named plex
 # make sure that your dns has a cname set for plexwebtools
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name plexwebtools.*;
 

--- a/podgrab.subdomain.conf.sample
+++ b/podgrab.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your podgrab container is named podgrab
 # make sure that your dns has a cname set for podgrab
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name podgrab.*;
 

--- a/portainer.subdomain.conf.sample
+++ b/portainer.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/12
+## Version 2023/05/31
 # make sure that your portainer container is named portainer
 # make sure that your dns has a cname set for portainer
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name portainer.*;
 

--- a/privatebin.subdomain.conf.sample
+++ b/privatebin.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your privatebin container is named privatebin
 # make sure that your dns has a cname set for privatebin
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name privatebin.*;
 

--- a/prometheus.subdomain.conf.sample
+++ b/prometheus.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/04/14
+## Version 2023/05/31
 # make sure that your prometheus container is named prometheus
 # make sure that your dns has a cname set for prometheus
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name prometheus.*;
 

--- a/prowlarr.subdomain.conf.sample
+++ b/prowlarr.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your prowlarr container is named prowlarr
 # make sure that your dns has a cname set for prowlarr
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name prowlarr.*;
 

--- a/pterodactyl.subdomain.conf.sample
+++ b/pterodactyl.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/05/08
+## Version 2023/05/31
 # this is for your actual panel, not nodes
 # make sure you set your pterodactyl servers "remote" and "api" addresses to the domains you specify here
 # ensure you have enabled "ssl encryption" and (if necessary) "behind proxy" in your pterodactyl server
@@ -6,8 +6,8 @@
 # make sure that your dns has a cname set for pterodactyl
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name pterodactyl.*;
 

--- a/pterodactylnode.subdomain.conf.sample
+++ b/pterodactylnode.subdomain.conf.sample
@@ -1,19 +1,19 @@
-## Version 2023/05/08
+## Version 2023/05/31
 # this is for nodes, not your actual panel
 # make sure you set your node to use 443 as its API port
 # make sure that your pterodactylnode container is named pterodactylnode
 # make sure that your dns has a cname set for pterodactylnode
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name pterodactylnode.*;
 
     include /config/nginx/ssl.conf;
 
     client_max_body_size 0;
-	
+
     # enable for ldap auth (requires ldap-location.conf in the location block)
     #include /config/nginx/ldap-server.conf;
 
@@ -37,7 +37,7 @@ server {
 
         # enable for Authentik (requires authentik-server.conf in the server block)
         #include /config/nginx/authentik-location.conf;
-		
+
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
         set $upstream_app pterodactylnode;
@@ -46,7 +46,7 @@ server {
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
     }
-    
+
     location ~ (/pterodactylnode)?/api {
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;

--- a/pwndrop.subdomain.conf.sample
+++ b/pwndrop.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your pwndrop container is named pwndrop
 # make sure that your dns has a cname set for pwndrop
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name pwndrop.*;
 

--- a/pydio-cells.subdomain.conf.sample
+++ b/pydio-cells.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your pydio-cells container is named pydio-cells
 # make sure that your dns has a cname set for pydio-cells
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name pydio-cells.*;
 

--- a/pydio.subdomain.conf.sample
+++ b/pydio.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your pydio container is named pydio
 # make sure that your dns has a cname set for pydio
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name pydio.*;
 

--- a/pyload.subdomain.conf.sample
+++ b/pyload.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your pyload container is named pyload
 # make sure that your dns has a cname set for pyload
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name pyload.*;
 

--- a/qbittorrent.subdomain.conf.sample
+++ b/qbittorrent.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your qbittorrent container is named qbittorrent
 # make sure that your dns has a cname set for qbittorrent
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name qbittorrent.*;
 

--- a/quassel-web.subdomain.conf.sample
+++ b/quassel-web.subdomain.conf.sample
@@ -1,11 +1,11 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your quassel container is named quassel-web
 # make sure that your dns has a cname set for quassel
 # make sure Quassel-Web is running on http with -e 'HTTPS'='false' or if you're using -e 'ADVANCED'='true' by editing config.json appropriately
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name quassel.*;
 

--- a/radarr.subdomain.conf.sample
+++ b/radarr.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your radarr container is named radarr
 # make sure that your dns has a cname set for radarr
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name radarr.*;
 

--- a/raneto.subdomain.conf.sample
+++ b/raneto.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your raneto container is named raneto
 # make sure that your dns has a cname set for raneto
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name raneto.*;
 

--- a/readarr.subdomain.conf.sample
+++ b/readarr.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your readarr container is named readarr
 # make sure that your dns has a cname set for readarr
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name readarr.*;
 

--- a/recipes.subdomain.conf.sample
+++ b/recipes.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your recipes container is named recipes
 # make sure that your dns has a cname set for recipes
 # make sure to mount /media/ in your swag container to point to your Recipes Media directory
@@ -7,8 +7,8 @@
 # Doc: https://vabene1111.github.io/recipes/install/docker/#using-proxy-authentication
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name recipes.*;
 

--- a/requestrr.subdomain.conf.sample
+++ b/requestrr.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your requestrr container is named requestrr
 # make sure that your dns has a cname set for requestrr
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name requestrr.*;
 

--- a/resilio-sync.subdomain.conf.sample
+++ b/resilio-sync.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your resilio-sync container is named resilio-sync
 # make sure that your dns has a cname set for resilio-sync
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name resilio-sync.*;
 

--- a/rutorrent.subdomain.conf.sample
+++ b/rutorrent.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your rutorrent container is named rutorrent
 # make sure that your dns has a cname set for rutorrent
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name rutorrent.*;
 

--- a/sabnzbd.subdomain.conf.sample
+++ b/sabnzbd.subdomain.conf.sample
@@ -1,12 +1,12 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your sabnzbd container is named sabnzbd
 # make sure that your dns has a cname set for sabnzbd
 # edit the sabnzbd.ini host_whitelist to avoid hostname verification issues. This format:
 # host_whitelist = sabnzbd.domain.com, www.sabnzbd.domain.com
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name sabnzbd.*;
 

--- a/scrutiny.subdomain.conf.sample
+++ b/scrutiny.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your scrutiny container is named scrutiny
 # make sure that your dns has a cname set for scrutiny
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name scrutiny.*;
 

--- a/shinobi.subdomain.conf.sample
+++ b/shinobi.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your shinobi container is named shinobi
 # make sure that your dns has a cname set for shinobi
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name shinobi.*;
 

--- a/sickchill.subdomain.conf.sample
+++ b/sickchill.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your sickchill container is named sickchill
 # make sure that your dns has a cname set for sickchill
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name sickchill.*;
 

--- a/sickrage.subdomain.conf.sample
+++ b/sickrage.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your sickrage container is named sickrage
 # make sure that your dns has a cname set for sickrage
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name sickrage.*;
 

--- a/skyhook.subdomain.conf.sample
+++ b/skyhook.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your skyhook container is named skyhook
 # make sure that your dns has a cname set for skyhook
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name skyhook.*;
 

--- a/smokeping.subdomain.conf.sample
+++ b/smokeping.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your smokeping container is named smokeping
 # make sure that your dns has a cname set for smokeping
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name smokeping.*;
 

--- a/sonarr.subdomain.conf.sample
+++ b/sonarr.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your sonarr container is named sonarr
 # make sure that your dns has a cname set for sonarr
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name sonarr.*;
 

--- a/statping.subdomain.conf.sample
+++ b/statping.subdomain.conf.sample
@@ -1,12 +1,12 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your statping container is named statup
 # make sure that your dns has a cname set for statping
 # If you are using the SSL docker-compose.yml on the statping repo, then the container name will be set to statup.
 # On other compose examples, it might be named statping. In that case, change $upstream_app statup to $upstream_app statping
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name statping.*;
 

--- a/synapse.subdomain.conf.sample
+++ b/synapse.subdomain.conf.sample
@@ -1,8 +1,8 @@
-## Version 2023/02/05
+## Version 2023/05/31
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     # For the federation port
     listen 8448 ssl;

--- a/synclounge.subdomain.conf.sample
+++ b/synclounge.subdomain.conf.sample
@@ -1,12 +1,12 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your synclounge container is named synclounge
 # make sure that your dns has a cname set for synclounge
 # Use this with SyncLounge v3 and up.
 # Make sure that you do not have HSTS enabled, otherwise http access won't work
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
     listen 80;
     listen [::]:80;
 

--- a/syncthing.subdomain.conf.sample
+++ b/syncthing.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/12
+## Version 2023/05/31
 # make sure that your syncthing container is named syncthing
 # make sure that your dns has a cname set for syncthing
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name syncthing.*;
 

--- a/taisun.subdomain.conf.sample
+++ b/taisun.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your taisun container is named taisun
 # make sure that your dns has a cname set for taisun
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name taisun.*;
 

--- a/tasmobackup.subdomain.conf.sample
+++ b/tasmobackup.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your tasmobackup container is named tasmobackup
 # make sure that your dns has a cname set for tasmobackup
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name tasmobackup.*;
 

--- a/tautulli.subdomain.conf.sample
+++ b/tautulli.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your tautulli container is named tautulli
 # make sure that your dns has a cname set for tautulli
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name tautulli.*;
 

--- a/tdarr.subdomain.conf.sample
+++ b/tdarr.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your tdarr container is named tdarr
 # make sure that your dns has a cname set for tdarr
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name tdarr.*;
 

--- a/thelounge.subdomain.conf.sample
+++ b/thelounge.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your thelounge container is named thelounge
 # make sure that your dns has a cname set for thelounge
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name thelounge.*;
 

--- a/themepark.subdomain.conf.sample
+++ b/themepark.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your theme-park. container is named theme-park.
 # make sure that your dns has a cname set for themepark.
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name themepark.*;
 

--- a/transmission.subdomain.conf.sample
+++ b/transmission.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # Make sure that DNS has a cname set for transmission
 #
 # Some Transmission Chrome extensions cannot handle HTTP/2 proxies as they
@@ -12,8 +12,8 @@
 # extension developer to fix their extensions to support HTTP/2.
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name transmission.*;
 

--- a/ubooquity.subdomain.conf.sample
+++ b/ubooquity.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your ubooquity container is named ubooquity
 # make sure that your dns has a cname set for ubooquity
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name ubooquity.*;
 

--- a/unifi-controller.subdomain.conf.sample
+++ b/unifi-controller.subdomain.conf.sample
@@ -1,12 +1,12 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your unifi-controller container is named unifi-controller
 # make sure that your dns has a cname set for unifi
 # NOTE: If you use the proxy_cookie_path setting in proxy.conf you need to remove HTTPOnly;
 # ex: proxy_cookie_path / "/; Secure";
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name unifi.*;
 

--- a/uptime-kuma.subdomain.conf.sample
+++ b/uptime-kuma.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your uptime-kuma container is named uptime-kuma
 # make sure that your dns has a cname set for uptime-kuma
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name uptime-kuma.*;
 

--- a/vaultwarden.subdomain.conf.sample
+++ b/vaultwarden.subdomain.conf.sample
@@ -1,11 +1,11 @@
-## Version 2023/03/27
+## Version 2023/05/31
 # make sure that your vaultwarden container is named vaultwarden
 # make sure that your dns has a cname set for vaultwarden
 # set the environment variable WEBSOCKET_ENABLED=true on your vaultwarden container
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name vaultwarden.*;
 

--- a/viewtube.subdomain.conf.sample
+++ b/viewtube.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your viewtube container is named viewtube
 # make sure that your dns has a cname set for viewtube
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name viewtube.*;
 

--- a/wallabag.subdomain.conf.sample
+++ b/wallabag.subdomain.conf.sample
@@ -1,12 +1,12 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your wallabag container is named wallabag
 # make sure that your dns has a cname set for wallabag
 # also, make sure your env var in your docker run or compose match the full domain, incl. https://
 # i.e. - SYMFONY__ENV__DOMAIN_NAME=https://wallabag.yourdomain.com
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name wallabag.*;
 

--- a/warpgate.subdomain.conf.sample
+++ b/warpgate.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your warpgate container is named warpgate
 # make sure that your dns has a cname set for warpgate
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name warpgate.*;
 

--- a/webtop.subdomain.conf.sample
+++ b/webtop.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that you have a cname set for the webtop
 # set up authentication here, for better security
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name webtop.*;
 

--- a/wizarr.subdomain.conf.sample
+++ b/wizarr.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your wizarr container is named wizarr
 # make sure that your dns has a cname set for wizarr
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name wizarr.*;
 

--- a/wordpress.subdomain.conf.sample
+++ b/wordpress.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/03/12
+## Version 2023/05/31
 # make sure that your wordpress container is named wordpress
 # make sure that your dns has a cname set for wordpress
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name wordpress.*;
 

--- a/wrapperr.subdomain.conf.sample
+++ b/wrapperr.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/17
+## Version 2023/05/31
 # make sure that your wrapperr container is named wrapperr
 # make sure that your dns has a cname set for wrapperr
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name wrapperr.*;
 

--- a/yacht.subdomain.conf.sample
+++ b/yacht.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your yacht container is named yacht
 # make sure that your dns has a cname set for yacht
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name yacht.*;
 

--- a/youtube-dl-server.subdomain.conf.sample
+++ b/youtube-dl-server.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your youtube-dl-server container is named youtube-dl-server
 # make sure that your dns has a cname set for youtube-dl-server
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name youtube-dl-server.*;
 

--- a/zigbee2mqtt.subdomain.conf.sample
+++ b/zigbee2mqtt.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your zigbee2mqtt container is named zigbee2mqtt
 # make sure that your dns has a cname set for zigbee2mqtt
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name zigbee2mqtt.*;
 

--- a/znc.subdomain.conf.sample
+++ b/znc.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your znc container is named znc
 # make sure that your dns has a cname set for znc
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name znc.*;
 

--- a/zwavejs2mqtt.subdomain.conf.sample
+++ b/zwavejs2mqtt.subdomain.conf.sample
@@ -1,10 +1,10 @@
-## Version 2023/02/05
+## Version 2023/05/31
 # make sure that your zwavejs2mqtt container is named zwavejs2mqtt
 # make sure that your dns has a cname set for zwavejs2mqtt
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
     server_name zwavejs2mqtt.*;
 


### PR DESCRIPTION
Closes https://github.com/linuxserver/docker-swag/issues/377

Specifics:

Existing confs are not causing broken instances, but are causing log warnings. The warning is stating that the protocols for the `listen` directive have been redefined after being set by another conf. Proxy confs did not previously include `http2` because https://www.nginx.com/blog/http2-module-nginx/#QandA

> Q: Will you support HTTP/2 on the upstream side as well, or only support HTTP/2 on the client side?

>
> A: At the moment, we only support HTTP/2 on the client side. You can’t configure HTTP/2 with [proxy_pass](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass). [Editor – In the original version of this post, this sentence was incorrectly transcribed as “You can configure HTTP/2 with proxy_pass.” We apologize for any confusion this may have caused.]

>
> But what is the point of HTTP/2 on the backend side? Because as you can see from the benchmarks, there’s not much benefit in HTTP/2 for low‑latency networks such as upstream connections.

>
> Also, in NGINX you have the [keepalive](https://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive) module, and you can configure a keepalive cache. The main performance benefit of HTTP/2 is to eliminate additional handshakes, but if you do that already with a keepalive cache, you don’t need HTTP/2 on the upstream side.

I still do not see any evidence that this has changed, but having the `http2` directive does not cause issues (it might just be ignored).