### PR TITLE
Add custom theme support for qBittorrent

### DIFF
--- a/qbittorrent.subdomain.conf.sample
+++ b/qbittorrent.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/05/31
+## Version 2023/06/14
 # make sure that your qbittorrent container is named qbittorrent
 # make sure that your dns has a cname set for qbittorrent
 

--- a/qbittorrent.subdomain.conf.sample
+++ b/qbittorrent.subdomain.conf.sample
@@ -136,4 +136,19 @@ server {
         proxy_set_header Host $upstream_app:$upstream_port;
         proxy_set_header X-Forwarded-Host $host;
     }
+
+    location ~ (/qbittorrent)?/css {
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app qbittorrent;
+        set $upstream_port 8080;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+        rewrite /qbittorrent(.*) $1 break;
+
+        proxy_set_header Referer '';
+        proxy_set_header Host $upstream_app:$upstream_port;
+        proxy_set_header X-Forwarded-Host $host;
+    }
 }

--- a/qbittorrent.subfolder.conf.sample
+++ b/qbittorrent.subfolder.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/02/05
+## Version 2023/06/14
 # make sure that your qbittorrent container is named qbittorrent
 # qbittorrent does not require a base url setting
 

--- a/qbittorrent.subfolder.conf.sample
+++ b/qbittorrent.subfolder.conf.sample
@@ -123,3 +123,18 @@ location ^~ /qbittorrent/scripts {
     proxy_set_header Host $upstream_app:$upstream_port;
     proxy_set_header X-Forwarded-Host $host;
 }
+
+location ^~ /qbittorrent/css {
+    include /config/nginx/proxy.conf;
+    include /config/nginx/resolver.conf;
+    set $upstream_app qbittorrent;
+    set $upstream_port 8080;
+    set $upstream_proto http;
+    proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    rewrite /qbittorrent(.*) $1 break;
+
+    proxy_set_header Referer '';
+    proxy_set_header Host $upstream_app:$upstream_port;
+    proxy_set_header X-Forwarded-Host $host;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
Add sections to qBittorrent configurations to route requests to `/css`

## Benefits of this PR and context
I was unable to load css assets when using a custom qBittorrent webUI. I saw that my requests to `qbittorrent.*/css/...` were being redirected to authelia. This change routes traffic to the correct container instead of redirecting.

## How Has This Been Tested?
I made the edits to the subdomain configuration in my existing swag/Bbittorrent stack and saw that the css requests were no longer being incorrectly redirected and that the custom styles were correctly applied. I unapplied the custom style through the qBittorrent options menu, restarted the qBittorrent container and saw that the original theme was not affected. 

I did not test the change to the subfolder configuration as I do not use subfolders and it would conflict with other services I have, but followed the same pattern as it was obvious how to make the correct configuration changes.

## Source / References
