### PR TITLE
Add shlink sample

### DIFF
--- a/shlink.subdomain.conf.sample
+++ b/shlink.subdomain.conf.sample
@@ -1,0 +1,45 @@
+## Version 2023/05/31
+# make sure that your shlink container is named shlink
+# make sure that your dns has a cname set for shlink
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+
+    server_name shlink.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    # enable for ldap auth (requires ldap-location.conf in the location block)
+    #include /config/nginx/ldap-server.conf;
+
+    # enable for Authelia (requires authelia-location.conf in the location block)
+    #include /config/nginx/authelia-server.conf;
+
+    # enable for Authentik (requires authentik-location.conf in the location block)
+    #include /config/nginx/authentik-server.conf;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable for ldap auth (requires ldap-server.conf in the server block)
+        #include /config/nginx/ldap-location.conf;
+
+        # enable for Authelia (requires authelia-server.conf in the server block)
+        #include /config/nginx/authelia-location.conf;
+
+        # enable for Authentik (requires authentik-server.conf in the server block)
+        #include /config/nginx/authentik-location.conf;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app shlink;
+        set $upstream_port 8080;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
Added a reverse proxy conf for the [Shlink](https://github.com/shlinkio/shlink) application based on a suggestion on the issue: https://github.com/linuxserver/docker-swag/issues/379#issuecomment-1596333902

## Benefits of this PR and context
Allow other users to easily configure a reverse proxy for an shlink instance.

## How Has This Been Tested?
Tested with Ubuntu Server 22.04 up-to-date and latest version of docker, docker-compose (based on [this](https://docs.docker.com/engine/install/ubuntu/) doc) and swag.
Used the `docker-compose.yaml` file present on this issue: https://github.com/linuxserver/docker-swag/issues/379

## Source / References
- Discussion on shlink repository: https://github.com/shlinkio/shlink/discussions/1796
- Issue on docker-swag repository: https://github.com/linuxserver/docker-swag/issues/379