### PR TITLE
Fix organizr settings to fit v2.1

### DIFF
--- a/organizr.subdomain.conf.sample
+++ b/organizr.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/05/31
+## Version 2023/06/20
 # make sure that your organizr container is named organizr
 # make sure that your dns has a cname set for organizr
 
@@ -34,6 +34,17 @@ server {
 
         # enable for Authentik (requires authentik-server.conf in the server block)
         #include /config/nginx/authentik-location.conf;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app organizr;
+        set $upstream_port 80;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    }
+
+    location ~ ^/api/v2/ {
 
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;

--- a/organizr.subfolder.conf.sample
+++ b/organizr.subfolder.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/02/05
+## Version 2023/06/20
 # make sure that your organizr container is named organizr
 # In order to use this location block you need to edit the default file one folder up and comment out the / and ~ \.php$ locations
 
@@ -15,6 +15,17 @@ location / {
 
     # enable for Authentik (requires authentik-server.conf in the server block)
     #include /config/nginx/authentik-location.conf;
+
+    include /config/nginx/proxy.conf;
+    include /config/nginx/resolver.conf;
+    set $upstream_app organizr;
+    set $upstream_port 80;
+    set $upstream_proto http;
+    proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+}
+
+location ~ ^/api/v2/ {
 
     include /config/nginx/proxy.conf;
     include /config/nginx/resolver.conf;


### PR DESCRIPTION
 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description

Organizr updated to version 2.1 and the previous conf file stopped working properly. The new conf needs a location for `/api/v2` as well, see [here](https://docs.organizr.app/help/faq/migration-guide#version-2-0-greater-than-version-2-1)

## Benefits of this PR and context
Organizr will no longer work with the previous proxy settings

## How Has This Been Tested?
Tested work with the default [organizr/organizr](https://hub.docker.com/r/organizr/organizr) image

## Source / References
https://docs.organizr.app/help/faq/migration-guide#version-2-0-greater-than-version-2-1