### PR TITLE
Nextcloud header adjustments

### DIFF
--- a/nextcloud.subdomain.conf.sample
+++ b/nextcloud.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/06/06
+## Version 2023/06/24
 # make sure that your nextcloud container is named nextcloud
 # make sure that your dns has a cname set for nextcloud
 # assuming this container is called "swag", edit your nextcloud container's config
@@ -32,8 +32,13 @@ server {
         set $upstream_proto https;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
-        # Uncomment X-Frame-Options directive in ssl.conf to pass security checks.
+        # Hide proxy response headers from Nextcloud that conflict with ssl.conf
+        proxy_hide_header Referrer-Policy;
+        proxy_hide_header X-Content-Type-Options;
         proxy_hide_header X-Frame-Options;
+        proxy_hide_header X-XSS-Protection;
+
+        # Disable proxy buffering
         proxy_buffering off;
     }
 }

--- a/nextcloud.subdomain.conf.sample
+++ b/nextcloud.subdomain.conf.sample
@@ -33,6 +33,7 @@ server {
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
         # Hide proxy response headers from Nextcloud that conflict with ssl.conf
+        # Uncomment the Optional additional headers in SWAG's ssl.conf to pass Nextcloud's security scan
         proxy_hide_header Referrer-Policy;
         proxy_hide_header X-Content-Type-Options;
         proxy_hide_header X-Frame-Options;

--- a/nextcloud.subfolder.conf.sample
+++ b/nextcloud.subfolder.conf.sample
@@ -40,6 +40,7 @@ location ^~ /nextcloud/ {
     proxy_ssl_session_reuse off;
 
     # Hide proxy response headers from Nextcloud that conflict with ssl.conf
+    # Uncomment the Optional additional headers in SWAG's ssl.conf to pass Nextcloud's security scan
     proxy_hide_header Referrer-Policy;
     proxy_hide_header X-Content-Type-Options;
     proxy_hide_header X-Frame-Options;

--- a/nextcloud.subfolder.conf.sample
+++ b/nextcloud.subfolder.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/06/06
+## Version 2023/06/24
 # make sure that your nextcloud container is named nextcloud
 # make sure that nextcloud is set to work with the base url /nextcloud/
 # Assuming this container is called "swag", edit your nextcloud container's config
@@ -34,10 +34,17 @@ location ^~ /nextcloud/ {
     proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
     rewrite /nextcloud(.*) $1 break;
-    # Uncomment X-Frame-Options directive in ssl.conf to pass security checks.
-    proxy_hide_header X-Frame-Options;
-    proxy_buffering off;
+
     proxy_set_header Range $http_range;
     proxy_set_header If-Range $http_if_range;
     proxy_ssl_session_reuse off;
+
+    # Hide proxy response headers from Nextcloud that conflict with ssl.conf
+    proxy_hide_header Referrer-Policy;
+    proxy_hide_header X-Content-Type-Options;
+    proxy_hide_header X-Frame-Options;
+    proxy_hide_header X-XSS-Protection;
+
+    # Disable proxy buffering
+    proxy_buffering off;
 }


### PR DESCRIPTION
Solved discord thread https://discord.com/channels/354974912613449730/1122102501672484935

This hides the response headers coming from nextcloud, which keeps the headers from swag's `ssl.conf`. The values for the headers are the same, so there is no conflict, but if nextcloud's response headers are not hidden then both nextcloud and swag's headers are included in the response, and duplicate response headers causes issues.