### PR TITLE
Add private docker registry

### DIFF
--- a/registry.subdomain.conf.sample
+++ b/registry.subdomain.conf.sample
@@ -1,0 +1,70 @@
+## Version 2023/07/12
+# make sure that your registry container is named registry
+# make sure that your dns has a cname set for registry
+# if you want to generate a registry password create a htpasswd file using e.g.:
+# `docker run --entrypoint htpasswd registry:2 -Bbn ${REGISTRY_USER} ${REGISTRY_PASS} > ${REGISTRY_ROOT}/auth/htpasswd`
+# and then pass it to the registry container using a volume mount
+#
+# Example snippet for a compose file (registry_network is shared with swag):
+# registry:
+#   image: registry:2.8.2
+#   container_name: registry
+#   volumes:
+#     - ${DOCKER_REGISTRY_ROOT}:/var/lib/registry
+#     - ${DOCKER_REGISTRY_ROOT}/auth:/auth
+#   environment:
+#     - REGISTRY_AUTH=htpasswd
+#     - REGISTRY_AUTH_HTPASSWD_REALM="Registry Realm"
+#     - REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd
+#   depends_on:
+#      - swag
+#   restart: always
+#   networks:
+#     - registry_network
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+
+    server_name registry.*;
+
+    include /config/nginx/ssl.conf;
+
+    # remove the maximum upload body-size so that the registry can handle large uploads
+    client_max_body_size 0;
+
+    # enable for ldap auth (requires ldap-location.conf in the location block)
+    #include /config/nginx/ldap-server.conf;
+
+    # enable for Authelia (requires authelia-location.conf in the location block)
+    #include /config/nginx/authelia-server.conf;
+
+    # enable for Authentik (requires authentik-location.conf in the location block)
+    #include /config/nginx/authentik-server.conf;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable for ldap auth (requires ldap-server.conf in the server block)
+        #include /config/nginx/ldap-location.conf;
+
+        # enable for Authelia (requires authelia-server.conf in the server block)
+        #include /config/nginx/authelia-location.conf;
+
+        # enable for Authentik (requires authentik-server.conf in the server block)
+        #include /config/nginx/authentik-location.conf;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app registry;
+        set $upstream_port 5000;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+        # fix for https://github.com/moby/moby/issues/1486
+        chunked_transfer_encoding on;
+    }
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
<!--- Describe your changes in detail -->
This adds a conf file to run a [Docker private registry](https://docs.docker.com/registry/) behind SWAG.

## Benefits of this PR and context
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Due to the changes on Docker Hub, people might be interested in hosting their own registry for containers.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Works using this docker-compose file:
```
version: "3"

networks:
  registry_network:

services:
  swag:
    image: lscr.io/linuxserver/swag:2.6.0-ls223
    container_name: swag
    cap_add:
      - NET_ADMIN
    environment:
      - PUID=1000
      - PGID=1000
      - TZ=${TIMEZONE}
      - URL=${SWAG_URL}
      - VALIDATION=${SWAG_VALIDATION}
      - DNSPLUGIN=${SWAG_DNSPLUGIN}
      - EMAIL=${EMAIL}
      - CERTPROVIDER=${SWAG_CERTPROVIDER}
    volumes:
      - ${SWAG_ROOT}:/config
    ports:
      - 443:443
      - 80:80
    restart: unless-stopped
    networks:
      - registry_network

  registry:
    image: registry:2.8.2
    container_name: registry
    volumes:
      - ${DOCKER_REGISTRY_ROOT}:/var/lib/registry
      - ${DOCKER_REGISTRY_ROOT}/auth:/auth
    environment:
      - REGISTRY_AUTH=htpasswd
      - REGISTRY_AUTH_HTPASSWD_REALM="Registry Realm"
      - REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd
    depends_on:
       - swag
    restart: always
    networks:
      - registry_network
```
where I have created a htpasswd using:
```
docker run --entrypoint htpasswd registry:2 -Bbn $registry_user $registry_pass > ${DOCKER_REGISTRY_ROOT}/auth/htpasswd
```

## Source / References
<!--- Please include any forum posts/github links relevant to the PR -->
Idea stemmed from this [blog post](https://medium.com/@victor.adascalitei/deploying-a-self-hosted-free-public-certified-docker-registry-the-docker-way-3bcc397270ca)