### PR TITLE
Update notifiarr.subdomain.conf.sample

### DIFF
--- a/notifiarr.subdomain.conf.sample
+++ b/notifiarr.subdomain.conf.sample
@@ -31,6 +31,9 @@ server {
 
         # enable for Authelia (requires authelia-server.conf in the server block)
         #include /config/nginx/authelia-location.conf;
+        # Enable if you use webauth for Notifiarr client website authentication
+        #proxy_set_header X-Forwarded-For $remote_addr;
+        #proxy_set_header X-WebAuth-User $user;
 
         # enable for Authentik (requires authentik-server.conf in the server block)
         #include /config/nginx/authentik-location.conf;

--- a/notifiarr.subdomain.conf.sample
+++ b/notifiarr.subdomain.conf.sample
@@ -32,7 +32,6 @@ server {
         # enable for Authelia (requires authelia-server.conf in the server block)
         #include /config/nginx/authelia-location.conf;
         # Enable if you use webauth for Notifiarr client website authentication
-        #proxy_set_header X-Forwarded-For $remote_addr;
         #proxy_set_header X-WebAuth-User $user;
 
         # enable for Authentik (requires authentik-server.conf in the server block)


### PR DESCRIPTION
Added proxy_set_header for Authelia authentication with Notifiarr.

Without these headers you will get a Logins Disabled message.

