### PR TITLE
Add `/s` auth bypass for Photoprism

### DIFF
--- a/photoprism.subdomain.conf.sample
+++ b/photoprism.subdomain.conf.sample
@@ -42,4 +42,12 @@ server {
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
     }
+    location ~ (/photoprism)?/s {
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app photoprism;
+        set $upstream_port 2342;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+    }
 }


### PR DESCRIPTION
`/s` is the path that corresponds to semi-publicly available share URLs in Photoprism (they still require a secret key in the URL), this commit make it so that they are bypassed by the authentification method.

As referenced in https://github.com/linuxserver/docker-mods/issues/372#issuecomment-1696145759 