### PR TITLE
Update komga.subfolder.conf.sample

### DIFF
--- a/komga.subfolder.conf.sample
+++ b/komga.subfolder.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/02/05
+## Version 2023/09/05
 # make sure that your komga container is named komga
 # make sure that komga is set to work with the base url /komga/
 # First make sure your Container has set an Baseurl set via docker-compose File "envirnoment: SERVER_SERVLET_CONTEXT_PATH=/komga" and recreate the container.

--- a/komga.subfolder.conf.sample
+++ b/komga.subfolder.conf.sample
@@ -24,7 +24,7 @@ location ^~ /komga/ {
     include /config/nginx/proxy.conf;
     include /config/nginx/resolver.conf;
     set $upstream_app komga;
-    set $upstream_port 8080 ;
+    set $upstream_port 25600 ;
     set $upstream_proto http;
     proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
@@ -34,7 +34,7 @@ location ^~ /komga/api {
     include /config/nginx/proxy.conf;
     include /config/nginx/resolver.conf;
     set $upstream_app komga;
-    set $upstream_port 8080;
+    set $upstream_port 25600;
     set $upstream_proto http;
     proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 }


### PR DESCRIPTION
2023/09/05


<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

docker has recently updated the port to 25600 from 8080
<!--- Describe your changes in detail -->

allows new deployment to work without end user having to modify the sample file manually
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

## How Has This Been Tested?
made the change on the file manually in my swag deployment without issues

## Source / References
in the breaking changes: https://komga.org/blog/prepare-v1/