### PR TITLE
Update komga.subdomain.conf.sample - updated the port to 25600 from 8080

### DIFF
--- a/komga.subdomain.conf.sample
+++ b/komga.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/05/31
+## Version 2023/09/05
 # make sure that your komga container is named komga
 # make sure that your dns has a cname set for komga
 

--- a/komga.subdomain.conf.sample
+++ b/komga.subdomain.conf.sample
@@ -38,7 +38,7 @@ server {
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
         set $upstream_app komga;
-        set $upstream_port 8080;
+        set $upstream_port 25600;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
@@ -48,7 +48,7 @@ server {
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
         set $upstream_app komga;
-        set $upstream_port 8080;
+        set $upstream_port 25600;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 


### PR DESCRIPTION
2023/09/05


<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

docker has recently updated the port to 25600 from 8080
<!--- Describe your changes in detail -->

allows new deployment to work without end user having to modify the sample file manually
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

## How Has This Been Tested?
made the change on the file manually in my swag deployment without issues

## Source / References
in the breaking changes: https://komga.org/blog/prepare-v1/