### PR TITLE
Create unifi-network-application.subdomain.conf.sample

### DIFF
--- a/unifi-network-application.subdomain.conf.sample
+++ b/unifi-network-application.subdomain.conf.sample
@@ -1,0 +1,49 @@
+## Version 2023/09/06
+# make sure that your unifi-network-application container is named unifi-network-application
+# make sure that your dns has a cname set for unifi
+# NOTE: If you use the proxy_cookie_path setting in proxy.conf you need to remove HTTPOnly;
+# ex: proxy_cookie_path / "/; Secure";
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+
+    server_name unifi.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    # enable for ldap auth (requires ldap-location.conf in the location block)
+    #include /config/nginx/ldap-server.conf;
+
+    # enable for Authelia (requires authelia-location.conf in the location block)
+    #include /config/nginx/authelia-server.conf;
+
+    # enable for Authentik (requires authentik-location.conf in the location block)
+    #include /config/nginx/authentik-server.conf;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable for ldap auth (requires ldap-server.conf in the server block)
+        #include /config/nginx/ldap-location.conf;
+
+        # enable for Authelia (requires authelia-server.conf in the server block)
+        #include /config/nginx/authelia-location.conf;
+
+        # enable for Authentik (requires authentik-server.conf in the server block)
+        #include /config/nginx/authentik-location.conf;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app unifi-network-application;
+        set $upstream_port 8443;
+        set $upstream_proto https;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+        proxy_buffering off;
+    }
+}


### PR DESCRIPTION
This is a proxy conf to support https://github.com/linuxserver/docker-unifi-network-application since both unifi-controller and unifi-network-application will exist for quite some time, we will need both for a bit. 