### PR TITLE
Update Prowlarr configs to create /download block

### DIFF
--- a/prowlarr.subdomain.conf.sample
+++ b/prowlarr.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/05/31
+## Version 2023/09/13
 # make sure that your prowlarr container is named prowlarr
 # make sure that your dns has a cname set for prowlarr
 
@@ -50,5 +50,15 @@ server {
         set $upstream_port 9696;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+    }
+
+    location ~ /prowlarr(/[0-9]+)?/download {
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app prowlarr;
+        set $upstream_port 9696;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
     }
 }

--- a/prowlarr.subdomain.conf.sample
+++ b/prowlarr.subdomain.conf.sample
@@ -52,7 +52,7 @@ server {
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
     }
 
-    location ~ /prowlarr(/[0-9]+)?/download {
+    location ~ (/prowlarr)?(/[0-9]+)?/download {
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
         set $upstream_app prowlarr;

--- a/prowlarr.subfolder.conf.sample
+++ b/prowlarr.subfolder.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/02/05
+## Version 2023/09/13
 # make sure that your prowlarr container is named prowlarr
 # make sure that prowlarr is set to work with the base url /prowlarr/
 
@@ -26,6 +26,16 @@ location /prowlarr {
 }
 
 location ~ /prowlarr(/[0-9]+)?/api {
+    include /config/nginx/proxy.conf;
+    include /config/nginx/resolver.conf;
+    set $upstream_app prowlarr;
+    set $upstream_port 9696;
+    set $upstream_proto http;
+    proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+}
+
+location ~ /prowlarr(/[0-9]+)?/download {
     include /config/nginx/proxy.conf;
     include /config/nginx/resolver.conf;
     set $upstream_app prowlarr;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
Downloads through Radarr seems to make requests to Prowlarr at /download instead of /api. In the old config, if the Authelia config is enabled, these /download requests would be blocked by Authelia

## Benefits of this PR and context
Mentioned above

## How Has This Been Tested?
Tested on latest Radarr stable (4.7.5.7809) and nightly (5.0.2.8062)

## Source / References
<!--- Please include any forum posts/github links relevant to the PR -->