### PR TITLE
Update mealie.subdomain.conf.sample

### DIFF
--- a/mealie.subdomain.conf.sample
+++ b/mealie.subdomain.conf.sample
@@ -37,7 +37,7 @@ server {
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
         set $upstream_app mealie;
-        set $upstream_port 80;
+        set $upstream_port 9000;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 


### PR DESCRIPTION
in v1.0 port was changed from 80 to 9000

closes https://github.com/linuxserver/reverse-proxy-confs/issues/621
