### PR TITLE
Added immich.subdomain.conf.sample

### DIFF
--- a/immich.subdomain.conf.sample
+++ b/immich.subdomain.conf.sample
@@ -1,0 +1,57 @@
+## Version 2023/11/26
+# make sure that your immich container is named immich
+# make sure that your dns has a cname set for immich
+# immich v1.88+ only
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+
+    server_name immich.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    # enable for ldap auth (requires ldap-location.conf in the location block)
+    #include /config/nginx/ldap-server.conf;
+
+    # enable for Authelia (requires authelia-location.conf in the location block)
+    #include /config/nginx/authelia-server.conf;
+
+    # enable for Authentik (requires authentik-location.conf in the location block)
+    #include /config/nginx/authentik-server.conf;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable for ldap auth (requires ldap-server.conf in the server block)
+        #include /config/nginx/ldap-location.conf;
+
+        # enable for Authelia (requires authelia-server.conf in the server block)
+        #include /config/nginx/authelia-location.conf;
+
+        # enable for Authentik (requires authentik-server.conf in the server block)
+        #include /config/nginx/authentik-location.conf;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app immich-server;
+        set $upstream_port 3001;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    }
+
+    location ~ (/immich)?/api {
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app immich-server;
+        set $upstream_port 3001;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
<!--- Describe your changes in detail -->
Added subdomain.conf.sample for Immich (https://github.com/immich-app/immich).

## Benefits of this PR and context
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Makes it clear to the users that the standard swag template works for Immich as well.
Looked through their Reverse Proxy guide (https://immich.app/docs/administration/reverse-proxy), but everything they suggest is aleady included in `/config/nginx/proxy.conf`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with a simple swag setup (duckdns with cert), but didn't try it with the optional auths.
Shared with others and it seems to work for them: https://github.com/immich-app/immich/discussions/1275#discussioncomment-7025968

## Source / References
<!--- Please include any forum posts/github links relevant to the PR -->
Immich repo: https://github.com/immich-app/immich
Immich docs: https://immich.app/docs/overview/introduction