### PR TITLE
Create wikijs.subdomain.conf.sample

### DIFF
--- a/influxdb.subdomain.conf.sample
+++ b/influxdb.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/12/21
+## Version 2023/05/31
 # make sure that your influxdb container is named influxdb
 # make sure that your dns has a cname set for influxdb
 
@@ -41,17 +41,6 @@ server {
         set $upstream_port 8086;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
-
-    }
-
-    location ~ (/influxdb)?/api {
-        include /config/nginx/proxy.conf;
-        include /config/nginx/resolver.conf;
-        set $upstream_app influxdb;
-        set $upstream_port 8086;
-        set $upstream_proto http;
-        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
-    
     }
 }
 

--- a/influxdb.subdomain.conf.sample
+++ b/influxdb.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/05/31
+## Version 2023/12/21
 # make sure that your influxdb container is named influxdb
 # make sure that your dns has a cname set for influxdb
 
@@ -41,6 +41,17 @@ server {
         set $upstream_port 8086;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    }
+
+    location ~ (/influxdb)?/api {
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app influxdb;
+        set $upstream_port 8086;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+    
     }
 }
 

--- a/wikijs.subdomain.conf.sample
+++ b/wikijs.subdomain.conf.sample
@@ -1,0 +1,54 @@
+## Version 2023/05/31
+# make sure that your wikijs container is named wikijs
+# make sure that your dns has a cname set for wikijs
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+
+    server_name wikijs.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    # enable for ldap auth (requires ldap-location.conf in the location block)
+    #include /config/nginx/ldap-server.conf;
+
+    # enable for Authelia (requires authelia-location.conf in the location block)
+    #include /config/nginx/authelia-server.conf;
+
+    # enable for Authentik (requires authentik-location.conf in the location block)
+    #include /config/nginx/authentik-server.conf;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable for ldap auth (requires ldap-server.conf in the server block)
+        #include /config/nginx/ldap-location.conf;
+
+        # enable for Authelia (requires authelia-server.conf in the server block)
+        #include /config/nginx/authelia-location.conf;
+
+        # enable for Authentik (requires authentik-server.conf in the server block)
+        #include /config/nginx/authentik-location.conf;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app wikijs;
+        set $upstream_port 3000;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+    }
+
+    location ~ (/wikijs)?/graphql {
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app wikijs;
+        set $upstream_port 3000;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+    }
+}

--- a/wikijs.subdomain.conf.sample
+++ b/wikijs.subdomain.conf.sample
@@ -41,6 +41,7 @@ server {
         set $upstream_port 3000;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
     }
 
     location ~ (/wikijs)?/graphql {
@@ -50,5 +51,6 @@ server {
         set $upstream_port 3000;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
     }
 }


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
Adds reverse proxy configuration for wiki.js docker container.

## Benefits of this PR and context
Adds missing reverse proxy configuration for [linuxserver/docker-wikijs](https://github.com/linuxserver/docker-wikijs), resolves stale PR #532.

## How Has This Been Tested?

This configuration has been tested by me, after incorporating wiki.js docker container into my production environment. (Tested on Wiki.js version `v2.5.300-ls123`).
Steps used to test the configuration:
1. Create and start Wiki.js docker container (with internal port set to 3000, as per docker container configuration);
2. Add this configuration file to `proxy-confs` swag directory and remove `.sample` suffix;
3. Set `wikijs` CNAME in your DNS provider configuration panel (Cloudflare was used during testing);
4. Restart both swag and wiki.js docker container;
5. Access wiki.js container by navigating to `https://wikijs.your-domain.tld`;
6. Remember to set site url to `https://wikijs.your-domain.tld` during initial wiki.js configuration.

## Source / References
[Wiki.js GraphQL API](https://docs.requarks.io/dev/api)
[Wiki.js Initial Configuration](https://docs.requarks.io/install/config)
[LinuxServer Subdomain Reverse Proxy Configuration Template](https://github.com/linuxserver/reverse-proxy-confs/blob/master/_template.subdomain.conf.sample)

Please ignore changes for `influxdb.subdomain.conf.sample`, as I pushed them to the wrong branch. The changes were reverted after I had noticed the mistake.