### PR TITLE
Secure cookies in heimdall.subdomain.conf.sample

### DIFF
--- a/heimdall.subdomain.conf.sample
+++ b/heimdall.subdomain.conf.sample
@@ -34,7 +34,7 @@ server {
 
         # enable for Authentik (requires authentik-server.conf in the server block)
         #include /config/nginx/authentik-location.conf;
-        
+
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
         set $upstream_app heimdall;

--- a/heimdall.subdomain.conf.sample
+++ b/heimdall.subdomain.conf.sample
@@ -35,6 +35,8 @@ server {
         # enable for Authentik (requires authentik-server.conf in the server block)
         #include /config/nginx/authentik-location.conf;
 
+        proxy_cookie_path / "/; Secure; SameSite=strict; HttpOnly";
+        
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
         set $upstream_app heimdall;

--- a/heimdall.subdomain.conf.sample
+++ b/heimdall.subdomain.conf.sample
@@ -41,6 +41,8 @@ server {
         set $upstream_port 443;
         set $upstream_proto https;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+        # Enable to secure cookies. Further reading here -> https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies
         #proxy_cookie_path / "/; Secure; SameSite=strict; HttpOnly";
 
     }

--- a/heimdall.subdomain.conf.sample
+++ b/heimdall.subdomain.conf.sample
@@ -34,8 +34,6 @@ server {
 
         # enable for Authentik (requires authentik-server.conf in the server block)
         #include /config/nginx/authentik-location.conf;
-
-        proxy_cookie_path / "/; Secure; SameSite=strict; HttpOnly";
         
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
@@ -43,6 +41,7 @@ server {
         set $upstream_port 443;
         set $upstream_proto https;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+        #proxy_cookie_path / "/; Secure; SameSite=strict; HttpOnly";
 
     }
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
The cookies are not secure by default with heimdall, we can force it through nginx.

## How Has This Been Tested?
The cookies are functional and can be seen through developer console on my instance -> https://services.simpleprivacy.fr/

![image](https://github.com/linuxserver/reverse-proxy-confs/assets/74207682/bedbd9b5-2b96-40d2-a507-6d1aa9afcfd4)