### PR TITLE
Add maintainerr.subdomain.conf.sample

### DIFF
--- a/maintainerr.subdomain.conf.sample
+++ b/maintainerr.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/05/31
+## Version 2023/12/14
 # make sure that your maintainerr container is named maintainerr
 # make sure that your dns has a cname set for maintainerr
 

--- a/maintainerr.subdomain.conf.sample
+++ b/maintainerr.subdomain.conf.sample
@@ -1,0 +1,47 @@
+## Version 2023/05/31
+# make sure that your maintainerr container is named maintainerr
+# make sure that your dns has a cname set for maintainerr
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+
+    server_name maintainerr.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    # enable for ldap auth (requires ldap-location.conf in the location block)
+    #include /config/nginx/ldap-server.conf;
+
+    # enable for Authelia (requires authelia-location.conf in the location block)
+    #include /config/nginx/authelia-server.conf;
+
+    # enable for Authentik (requires authentik-location.conf in the location block)
+    #include /config/nginx/authentik-server.conf;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable for ldap auth (requires ldap-server.conf in the server block)
+        #include /config/nginx/ldap-location.conf;
+
+        # enable for Authelia (requires authelia-server.conf in the server block)
+        #include /config/nginx/authelia-location.conf;
+
+        # enable for Authentik (requires authentik-server.conf in the server block)
+        #include /config/nginx/authentik-location.conf;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app maintainerr;
+        set $upstream_port 80;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    }
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
Adds support for [Maintainerr](https://github.com/jorenn92/Maintainerr)

All I did was `s/foo/bar` a few things and remove a few commented lines that said to remove them. I think this should be fine, though!
<!--- Describe your changes in detail -->

## Benefits of this PR and context
[Maintainerr](https://github.com/jorenn92/Maintainerr) sounds like it could be pretty useful. Since I like to put things like this behind Authentik, and I use SWAG as a reverse proxy for doing so, I wanted to contribute my added proxy conf.

Please note that the only reason I didn't add a `subfolder.conf.sample` is because I never use subfolders, and so I don't want to add it without testing — I don't see any technical reason why a subfolder conf can't just be added as well, but I'd rather not do it myself.

<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

## How Has This Been Tested?
As of writing this, the relevant part of my setup consists of one VM host with a private IP running SWAG as a standalone Docker Compose project, with lines in its `docker-compose.yml` to add a new bridge network named `swag`:
```yaml
#...snip...
services:
  swag:
    networks: ["swag"]
    #...snip...
networks:
  swag:
    name: swag
```

And then I have in another Compose project:
```yaml
#...snip...
services:
  maintainerr-service:
    container_name: maintainerr
    networks: ["swag"]
    #...snip...
networks:
  swag:
    external: true
```

And I also have Authentik running as an external LXC container, which I tested with this setup by uncommenting the relevant lines in the `conf.sample` file.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Source / References
<!--- Please include any forum posts/github links relevant to the PR -->