### PR TITLE
Add StirlingPDF subdomain and subfolder sample configs

### DIFF
--- a/stirling-pdf.subdomain.conf.sample
+++ b/stirling-pdf.subdomain.conf.sample
@@ -1,0 +1,46 @@
+## Version 2023/05/31
+# make sure that your StirlingPDF container is named StirlingPDF
+# make sure that your dns has a cname set for StirlingPDF
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+
+    server_name StirlingPDF.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    # enable for ldap auth (requires ldap-location.conf in the location block)
+    #include /config/nginx/ldap-server.conf;
+
+    # enable for Authelia (requires authelia-location.conf in the location block)
+    #include /config/nginx/authelia-server.conf;
+
+    # enable for Authentik (requires authentik-location.conf in the location block)
+    #include /config/nginx/authentik-server.conf;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable for ldap auth (requires ldap-server.conf in the server block)
+        #include /config/nginx/ldap-location.conf;
+
+        # enable for Authelia (requires authelia-server.conf in the server block)
+        #include /config/nginx/authelia-location.conf;
+
+        # enable for Authentik (requires authentik-server.conf in the server block)
+        #include /config/nginx/authentik-location.conf;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app StirlingPDF;
+        set $upstream_port 8080;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    }
+}

--- a/stirling-pdf.subfolder.conf.sample
+++ b/stirling-pdf.subfolder.conf.sample
@@ -1,0 +1,31 @@
+## Version 2023/02/05
+# make sure that your StirlingPDF container is named StirlingPDF
+# make sure that StirlingPDF is set to work with the base url /StirlingPDF/
+
+
+location /StirlingPDF {
+    return 301 $scheme://$host/StirlingPDF/;
+}
+
+location ^~ /StirlingPDF/ {
+    # enable the next two lines for http auth
+    #auth_basic "Restricted";
+    #auth_basic_user_file /config/nginx/.htpasswd;
+
+    # enable for ldap auth (requires ldap-server.conf in the server block)
+    #include /config/nginx/ldap-location.conf;
+
+    # enable for Authelia (requires authelia-server.conf in the server block)
+    #include /config/nginx/authelia-location.conf;
+
+    # enable for Authentik (requires authentik-server.conf in the server block)
+    #include /config/nginx/authentik-location.conf;
+
+    include /config/nginx/proxy.conf;
+    include /config/nginx/resolver.conf;
+    set $upstream_app StirlingPDF;
+    set $upstream_port 8080;
+    set $upstream_proto http;
+    proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [✔️] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
This adds stirling-pdf.subdomain.conf.sample based on the template _template.subdomain.conf.sample.
This adds stirling-pdf.subfolder.conf.sample based on the template _template.subfolder.conf.sample.

## Benefits of this PR and context
This PR can help people who would like to use StirlingPDF behind the "swag"-proxy.

## How Has This Been Tested?
I've been using this SWAG subdomain configuration for a while now. SWAG runs on my unraid server and is used to work as reverse-proxy and to optain SSL CERTs. It worked great.


## Source / References
[StirlingPDF on GitHub](https://github.com/Stirling-Tools/Stirling-PDF)
[StirlingPDF on Dockerhub](https://hub.docker.com/r/frooodle/s-pdf)