### PR TITLE
Disable external authorization for Influxdb API endpoint

### DIFF
--- a/influxdb.subdomain.conf.sample
+++ b/influxdb.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2024/01/05
+## Version 2024/01/08
 # make sure that your influxdb container is named influxdb
 # make sure that your dns has a cname set for influxdb
 
@@ -51,7 +51,6 @@ server {
         set $upstream_port 8086;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
-
+    
     }
 }
-

--- a/influxdb.subdomain.conf.sample
+++ b/influxdb.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/05/31
+## Version 2024/01/05
 # make sure that your influxdb container is named influxdb
 # make sure that your dns has a cname set for influxdb
 
@@ -41,6 +41,17 @@ server {
         set $upstream_port 8086;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    }
+
+    location ~ (/influxdb)?/api {
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app influxdb;
+        set $upstream_port 8086;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
     }
 }
 


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description
In its current state in order to access the API endpoint, both internal (built-in to the influxdb API) and external (LDAP, authelia or authentik) authorization is required. The latter authentication method is unnecessary, due to the current API requirement (i.e. to access the endpoint, a user is required to authorize with either `token`, `querystring` or `basic` authentication method).

## Benefits of this PR and context
This PR would disable external authorization for the API endpoint, thus making it easier to access the API endpoint in scripts (i.e. only requiring to authenticate with influxdb when making a request to the API).

## How Has This Been Tested?
This configuration has been tested by me, after incorporating it into my production environment. (Tested on InfluxDB version `2.7-alpine`).
Steps used to test the configuration:
 - Update `influxdb.subdomain.conf` to match the contents of this PR;
 - Restart `swag` and `influxdb` docker containers;
 - Make a request to the influxdb API endpoint.

## Source / References
[InfluxDB API Documentation](https://docs.influxdata.com/influxdb/v2/api/)