### PR TITLE
Create homepage.subfolder.conf.sample

### DIFF
--- a/homepage.subfolder.conf.sample
+++ b/homepage.subfolder.conf.sample
@@ -1,0 +1,26 @@
+## Version 2024/01/19
+# make sure that your homepage container is named homepage
+# In order to use this location block you need to edit the default file one folder up and comment out the / location
+
+location / {
+    # enable the next two lines for http auth
+    #auth_basic "Restricted";
+    #auth_basic_user_file /config/nginx/.htpasswd;
+
+    # enable for ldap auth (requires ldap-server.conf in the server block)
+    #include /config/nginx/ldap-location.conf;
+
+    # enable for Authelia (requires authelia-server.conf in the server block)
+    #include /config/nginx/authelia-location.conf;
+
+    # enable for Authentik (requires authentik-server.conf in the server block)
+    #include /config/nginx/authentik-location.conf;
+
+    include /config/nginx/proxy.conf;
+    include /config/nginx/resolver.conf;
+
+    set $upstream_app homepage;
+    set $upstream_port 3000;
+    set $upstream_proto http;
+    proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
This adds a sample subfolder config to use [homepage](https://gethomepage.dev/latest/) with SWAG.
The config directs the root `/` to homepage (e.g. mydomain.com).
This is based off the `Heimdall` config.

## Benefits of this PR and context
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

## How Has This Been Tested?
This has been tested on my own server.

## Source / References
https://github.com/gethomepage/homepage