### PR TITLE
Created rallly.subdomain.conf.sample

### DIFF
--- a/rallly.subdomain.conf.sample
+++ b/rallly.subdomain.conf.sample
@@ -1,0 +1,46 @@
+## Version 2023/05/31
+# make sure that your <container_name> container is named rallly
+# make sure that your dns has a cname set for rallly
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+
+    server_name rallly.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    # enable for ldap auth (requires ldap-location.conf in the location block)
+    #include /config/nginx/ldap-server.conf;
+
+    # enable for Authelia (requires authelia-location.conf in the location block)
+    #include /config/nginx/authelia-server.conf;
+
+    # enable for Authentik (requires authentik-location.conf in the location block)
+    #include /config/nginx/authentik-server.conf;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable for ldap auth (requires ldap-server.conf in the server block)
+        #include /config/nginx/ldap-location.conf;
+
+        # enable for Authelia (requires authelia-server.conf in the server block)
+        #include /config/nginx/authelia-location.conf;
+
+        # enable for Authentik (requires authentik-server.conf in the server block)
+        #include /config/nginx/authentik-location.conf;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app rallly;
+        set $upstream_port 3000;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    }
+}

--- a/rallly.subdomain.conf.sample
+++ b/rallly.subdomain.conf.sample
@@ -1,5 +1,5 @@
 ## Version 2023/05/31
-# make sure that your <container_name> container is named rallly
+# make sure that your rallly container is named rallly
 # make sure that your dns has a cname set for rallly
 
 server {


### PR DESCRIPTION
subdomain proxy config for Rallly App

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
<!--- Describe your changes in detail -->
I recently discovered Rallly which is scheduling software similar to Doodle (polling with Calendar). I created a proxy config that I tested and can verify that it works so that if others want to use this software with SWAG, they can easily.
## Benefits of this PR and context
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Allows the use of user funded software to be used with SWAG easily. 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested the subdomain only since that is the approach that I use. 
## Source / References
<!--- Please include any forum posts/github links relevant to the PR -->
[Rallly](https://rallly.co)