### PR TITLE
Adds section for Uptime Kuma status pages

### DIFF
--- a/uptime-kuma.subdomain.conf.sample
+++ b/uptime-kuma.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/05/31
+## Version 2024/03/26
 # make sure that your uptime-kuma container is named uptime-kuma
 # make sure that your dns has a cname set for uptime-kuma
 
@@ -35,6 +35,16 @@ server {
         # enable for Authentik (requires authentik-server.conf in the server block)
         #include /config/nginx/authentik-location.conf;
 
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app uptime-kuma;
+        set $upstream_port 3001;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    }
+
+    location ~ /(status|assets|icon.svg) {
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
         set $upstream_app uptime-kuma;


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [✅] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description
Uptime Kuma supports creating status pages. These do not require access to the dashboard (the admin backend), which you might have protected behind authentication. If you've enabled basic auth, LDAP, Authelia, or Authentik, you might want users to be able to reach your status page without having to disable that completely for your entire Uptime Kuma installation.

## Benefits of this PR and context
This PR adds a `location` section that allows the status page (and the assets it loads) to bypass any authentication you might have set up.

## How Has This Been Tested?
Admittedly, my setup is somewhat complicated. I have two servers: one running Unraid 6.12.8 and SWAG (plus the majority of my containers), and another running Ubuntu, Docker, and Uptime Kuma (as the only container). I am using Tailscale to allow SWAG to proxy communication to the Uptime Kuma server, so people can reach my status page without needing access via Tailscale.

I haven't tested this reverse proxy config exactly as-is, since I had to change the `upstream_app`, `upstream_port`, and `upstream_proto` to accommodate for my setup, but I'm confident that it should work if your SWAG and Uptime Kuma containers are on the same host.

## Source / References
I'm not great at regex, so I found a Stack Overflow post that gave me enough guidance to figure out how to do this without three additional `location` sections.

Also, I'd really appreciate someone making sure I put the curly braces in the right places. I used the Prowlarr config as a reference, as well as the included template.

Thank you for this project, and your continued work to maintain it!