### PR TITLE
Add configurations for Sonarr to RSS

### DIFF
--- a/sonarrtorss.subdomain.conf.sample
+++ b/sonarrtorss.subdomain.conf.sample
@@ -1,0 +1,54 @@
+## Version 2024/06/21
+# make sure that your sonarrtorss container is named sonarrtorss
+# make sure that your dns has a cname set for sonarrtorss
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+
+    server_name sonarrtorss.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    # enable for ldap auth (requires ldap-location.conf in the location block)
+    #include /config/nginx/ldap-server.conf;
+
+    # enable for Authelia (requires authelia-location.conf in the location block)
+    #include /config/nginx/authelia-server.conf;
+
+    # enable for Authentik (requires authentik-location.conf in the location block)
+    #include /config/nginx/authentik-server.conf;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable for ldap auth (requires ldap-server.conf in the server block)
+        #include /config/nginx/ldap-location.conf;
+
+        # enable for Authelia (requires authelia-server.conf in the server block)
+        #include /config/nginx/authelia-location.conf;
+
+        # enable for Authentik (requires authentik-server.conf in the server block)
+        #include /config/nginx/authentik-location.conf;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app sonarrtorss;
+        set $upstream_port 18989;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+    }
+
+    location ~ ^/(api/|sonarr$|rss$|atom$|json$) {
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app sonarrtorss;
+        set $upstream_port 18989;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+    }
+}

--- a/sonarrtorss.subfolder.conf.sample
+++ b/sonarrtorss.subfolder.conf.sample
@@ -1,0 +1,38 @@
+## Version 2024/06/21
+# make sure that your sonarrtorss container is named sonarrtorss
+# sonarrtorss does not require a base url setting
+
+location ^~ /sonarrtorss {
+    # enable the next two lines for http auth
+    #auth_basic "Restricted";
+    #auth_basic_user_file /config/nginx/.htpasswd;
+
+    # enable for ldap auth (requires ldap-server.conf in the server block)
+    #include /config/nginx/ldap-location.conf;
+
+    # enable for Authelia (requires authelia-server.conf in the server block)
+    #include /config/nginx/authelia-location.conf;
+
+    # enable for Authentik (requires authentik-server.conf in the server block)
+    #include /config/nginx/authentik-location.conf;
+
+    include /config/nginx/proxy.conf;
+    include /config/nginx/resolver.conf;
+    set $upstream_app sonarrtorss;
+    set $upstream_port 18989;
+    set $upstream_proto http;
+    proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    rewrite /sonarrtorss(.*) $1 break;
+}
+
+location ~ ^/sonarrtorss/(api/|sonarr$|rss$|atom$|json$) {
+    include /config/nginx/proxy.conf;
+    include /config/nginx/resolver.conf;
+    set $upstream_app sonarrtorss;
+    set $upstream_port 18989;
+    set $upstream_proto http;
+    proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    rewrite /sonarrtorss(.*) $1 break;
+}


### PR DESCRIPTION
Add proxy configurations for Sonarr to RSS

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [ X ] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description

Sonarr to RSS is a new Sonarr helper app.  

https://github.com/gbendy/sonarrToRSS/
https://registry.hub.docker.com/r/gbendy/sonarrtorss/

This PR adds both subdomain and subfolder reverse proxy support to Swag. The application supports both types of reverse proxy natively.

## Benefits of this PR and context

Users can configure swag without having to manually install configurations files from the app repository

## How Has This Been Tested?

Have been running the subdomain configuration myself for over a week with no problems.

Have run subfolder proxy for long enough to test that all endpoints work.

Have run both with authentication enabled and ensured that the 'api' endpoints are exempt from authentication and the user endpoints are not.

## Source / References

N/A