### PR TITLE
feat: add proxy-conf samples for forgejo

### DIFF
--- a/forgejo.subdomain.conf.sample
+++ b/forgejo.subdomain.conf.sample
@@ -1,0 +1,61 @@
+## Version 2024/04/20
+# make sure that your forgejo container is named forgejo
+# make sure that your dns has a cname set for forgejo
+# edit the following parameters in /data/forgejo/conf/app.ini or set as ENV vars in your container
+# [server]
+# SSH_DOMAIN       = forgejo.example.com
+# ROOT_URL         = https://forgejo.example.com/
+# DOMAIN           = forgejo.example.com
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+
+    server_name forgejo.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    # enable for ldap auth (requires ldap-location.conf in the location block)
+    #include /config/nginx/ldap-server.conf;
+
+    # enable for Authelia (requires authelia-location.conf in the location block)
+    #include /config/nginx/authelia-server.conf;
+
+    # enable for Authentik (requires authentik-location.conf in the location block)
+    #include /config/nginx/authentik-server.conf;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable for ldap auth (requires ldap-server.conf in the server block)
+        #include /config/nginx/ldap-location.conf;
+
+        # enable for Authelia (requires authelia-server.conf in the server block)
+        #include /config/nginx/authelia-location.conf;
+
+        # enable for Authentik (requires authentik-server.conf in the server block)
+        #include /config/nginx/authentik-location.conf;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app forgejo;
+        set $upstream_port 3000;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    }
+
+    location ~ (/forgejo)?/info/lfs {
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app forgejo;
+        set $upstream_port 3000;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    }
+}

--- a/forgejo.subfolder.conf.sample
+++ b/forgejo.subfolder.conf.sample
@@ -1,0 +1,24 @@
+## Version 2024/04/20
+# make sure that your forgejo container is named forgejo
+# make sure that forgejo is set to work with the base url /forgejo/
+# The following parameters in /data/forgejo/conf/app.ini should be edited to match your setup
+# or set as ENV vars in your container
+# [server]
+# SSH_DOMAIN       = example.com:2222
+# ROOT_URL         = https://example.com/forgejo/
+# DOMAIN           = example.com
+
+location /forgejo {
+    return 301 $scheme://$host/forgejo/;
+}
+
+location ^~ /forgejo/ {
+    include /config/nginx/proxy.conf;
+    include /config/nginx/resolver.conf;
+    set $upstream_app forgejo;
+    set $upstream_port 3000;
+    set $upstream_proto http;
+    proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    rewrite /forgejo(.*) $1 break;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
provide forgejo proxy-conf samples for subdomain and subfolder based on gitea samples.

## Benefits of this PR and context
expands built in swag support

## How Has This Been Tested?
tested an am using locally

## Source / References
<!--- Please include any forum posts/github links relevant to the PR -->