### PR TITLE
Nextcloud: update WebDAV URL redirects for subfolder

### DIFF
--- a/nextcloud.subfolder.conf.sample
+++ b/nextcloud.subfolder.conf.sample
@@ -1,4 +1,4 @@
-## Version 2024/04/25
+## Version 2024/04/28
 # make sure that your nextcloud container is named nextcloud
 # make sure that nextcloud is set to work with the base url /nextcloud/
 # Assuming this container is called "swag", edit your nextcloud container's config
@@ -48,4 +48,8 @@ location ^~ /nextcloud/ {
 
     # Disable proxy buffering
     proxy_buffering off;
+
+    # Nextcloud's redirect for these two `/.well-known` URIs in version 29 did not consider overwritewebroot
+    location = /nextcloud/.well-known/carddav { return 301 /nextcloud/remote.php/dav/; }
+    location = /nextcloud/.well-known/caldav { return 301 /nextcloud/remote.php/dav/; }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
<!--- Describe your changes in detail -->
There's existing redirect from `/.well-known/carddav` and `/.well-known/caldav` to `/nextcloud/remote.php/dav/`. 

However, in Nextcloud version 29, it will check for `/nextcloud/.well-known/carddav` which Nextcloud will then resolve to `/remote.php/dav/` regardless of `overwritewebroot` config and will not reach the Nextcloud endpoint.

## Benefits of this PR and context
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Removes a warning in Nextcloud's "Security & setup warnings" page

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Removes the warning on my configuration with default `lscr.io/linuxserver/swag:2.10.0` and `lscr.io/linuxserver/nextcloud:29.0.0`

## Source / References
<!--- Please include any forum posts/github links relevant to the PR -->