### PR TITLE
Create joplin.subdomain.conf.sample

### DIFF
--- a/joplin.subdomain.conf.sample
+++ b/joplin.subdomain.conf.sample
@@ -3,8 +3,8 @@
 # make sure that your dns has a cname set for joplin
 
 server {
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443 ssl;
+    listen [::]:443 ssl;
 
     server_name joplin.*;
 

--- a/joplin.subdomain.conf.sample
+++ b/joplin.subdomain.conf.sample
@@ -1,0 +1,46 @@
+## Version 2024/06/04
+# make sure that your joplin container is named joplin
+# make sure that your dns has a cname set for joplin
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+
+    server_name joplin.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    # enable for ldap auth (requires ldap-location.conf in the location block)
+    #include /config/nginx/ldap-server.conf;
+
+    # enable for Authelia (requires authelia-location.conf in the location block)
+    #include /config/nginx/authelia-server.conf;
+
+    # enable for Authentik (requires authentik-location.conf in the location block)
+    #include /config/nginx/authentik-server.conf;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable for ldap auth (requires ldap-server.conf in the server block)
+        #include /config/nginx/ldap-location.conf;
+
+        # enable for Authelia (requires authelia-server.conf in the server block)
+        #include /config/nginx/authelia-location.conf;
+
+        # enable for Authentik (requires authentik-server.conf in the server block)
+        #include /config/nginx/authentik-location.conf;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app joplin;
+        set $upstream_port 22300;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    }
+}


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description
I created this reverse proxy conf for the official Docker image of Joplin (or as Joplin calls it 'Joplin Server').
I refer to this as just 'Joplin', because Joplin does not have any other products that are distributed as Docker image.

## Benefits of this PR and context
This PR adds yet another service to SWAG for ease of use.
Joplin Server provides a way to host your own instance of Joplin sync server, thus keeping your notes syncronized.

## How Has This Been Tested?
Initially I setup Joplin as instructed on `Reference 2`.
Then, I created this config and used it with SWAG.
Works straight out of the box with default setup.

However, I have not tested (as in uncommented and ran) the following integrations in this config as I currently don't use them:
- ldap
- Authelia
- Authentik
- http auth

## Source / References
- Reference 1
  - The Github page for Joplin: https://github.com/laurent22/joplin
- Reference 2
  - Official Joplin Server Docker image: https://hub.docker.com/r/joplin/server
- Reference 3, for more Docker environment variables
  - https://github.com/laurent22/joplin/blob/f938d5f4893c54d5fb22efb8959c295da4f9189a/packages/server/src/env.ts