### PR TITLE
Update nextcloud's instructions

### DIFF
--- a/nextcloud.subdomain.conf.sample
+++ b/nextcloud.subdomain.conf.sample
@@ -1,18 +1,15 @@
-## Version 2024/04/25
+## Version 2024/07/06
 # make sure that your nextcloud container is named nextcloud
+# make sure that your nextcloud container is on the same docker network as swag
 # make sure that your dns has a cname set for nextcloud
-# assuming this container is called "swag", edit your nextcloud container's config
-# located at /config/www/nextcloud/config/config.php and add the following lines before the ");":
-#  'trusted_proxies' => [gethostbyname('swag')],
+# edit your nextcloud container's config located at
+# /config/www/nextcloud/config/config.php and add the following lines before the ");":
+#  'trusted_proxies' => ['172.16.0.0/12'],
 #  'overwrite.cli.url' => 'https://nextcloud.example.com/',
 #  'overwritehost' => 'nextcloud.example.com',
 #  'overwriteprotocol' => 'https',
-#
-# Also don't forget to add your domain name to the trusted domains array. It should look somewhat like this:
-#  array (
-#    0 => '192.168.0.1:444', # This line may look different on your setup, don't modify it.
-#    1 => 'nextcloud.example.com',
-#  ),
+# add your domain name to the trusted domains array:
+#  'trusted_domains' => ['nextcloud.example.com'],
 
 server {
     listen 443 ssl http2;

--- a/nextcloud.subfolder.conf.sample
+++ b/nextcloud.subfolder.conf.sample
@@ -1,17 +1,14 @@
-## Version 2024/04/25
+## Version 2024/07/06
 # make sure that your nextcloud container is named nextcloud
+# make sure that your nextcloud container is on the same docker network as swag
 # make sure that nextcloud is set to work with the base url /nextcloud/
-# Assuming this container is called "swag", edit your nextcloud container's config
-# located at /config/www/nextcloud/config/config.php and add the following lines before the ");":
-#  'trusted_proxies' => [gethostbyname('swag')],
+# edit your nextcloud container's config located at
+# /config/www/nextcloud/config/config.php and add the following lines before the ");":
+#  'trusted_proxies' => ['172.16.0.0/12'],
 #  'overwritewebroot' => '/nextcloud',
 #  'overwrite.cli.url' => 'https://example.com/nextcloud',
-#
-# Also don't forget to add your domain name to the trusted domains array. It should look somewhat like this:
-#  array (
-#    0 => '192.168.0.1:444', # This line may look different on your setup, don't modify it.
-#    1 => 'example.com',
-#  ),
+# add your domain name to the trusted domains array:
+#  'trusted_domains' => ['nextcloud.example.com'],
 
 location ^~ /.well-known {
     # The rules in this block are an adaptation of the rules


### PR DESCRIPTION
We're getting a lot of support questions regarding `trusted_proxies` and `gethostbyname`, changing the instructions to be more fool-proof