### PR TITLE
Update dashy V3 port

### DIFF
--- a/dashy.subdomain.conf.sample
+++ b/dashy.subdomain.conf.sample
@@ -38,7 +38,7 @@ server {
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
         set $upstream_app dashy;
-        set $upstream_port 80;
+        set $upstream_port 8080;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
Updated the proxy configuration for Dashy to reflect the change in the official image's port from 80 to 8080.

## Benefits of this PR and context
This change ensures that the proxy configuration works correctly with the updated Dashy image, which now listens on port 8080 instead of 80. It resolves the issue where users might face connectivity problems due to the incorrect port configuration.

## How Has This Been Tested?
Tested the updated proxy configuration in a local development environment to confirm that Dashy is accessible through the proxy on port 8080. Verified that the change does not affect other areas of the code or proxy configurations.

## Source / References
https://github.com/Lissy93/dashy/discussions/1529
closes https://github.com/linuxserver/reverse-proxy-confs/issues/685
