### PR TITLE
Add Subdomain Configuration for Seafile

### DIFF
--- a/seafile.subdomain.conf.sample
+++ b/seafile.subdomain.conf.sample
@@ -1,9 +1,10 @@
+## Version 2024/08/13
+# make sure that your seafile container is named seafile
+# make sure that your dns has a cname set for seafile
+
 server {
     listen 443 ssl;
     listen [::]:443 ssl;
-
-# make sure that your seafile container is named seafile
-# make sure that your dns has a cname set for seafile
 
     server_name seafile.*; # update to match the full domain e.g. seafile.example.com
 

--- a/seafile.subdomain.conf.sample
+++ b/seafile.subdomain.conf.sample
@@ -14,6 +14,7 @@ server {
 
     location / {
         include /config/nginx/resolver.conf;
+        include /config/nginx/proxy.conf;
         proxy_pass http://seafile:8000;
         proxy_read_timeout 310s;
         proxy_set_header Host $host;
@@ -29,6 +30,7 @@ server {
 
     location /seafhttp {
         include /config/nginx/resolver.conf;
+        include /config/nginx/proxy.conf;
         rewrite ^/seafhttp(.*)$ $1 break;
         proxy_pass http://seafile:8082;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/seafile.subdomain.conf.sample
+++ b/seafile.subdomain.conf.sample
@@ -16,7 +16,6 @@ server {
         include /config/nginx/resolver.conf;
         include /config/nginx/proxy.conf;
         proxy_pass http://seafile:8000;
-        proxy_read_timeout 310s;
         proxy_set_header Host $host;
         proxy_set_header Forwarded "for=$remote_addr;proto=$scheme";
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/seafile.subdomain.conf.sample
+++ b/seafile.subdomain.conf.sample
@@ -32,10 +32,9 @@ server {
         rewrite ^/seafhttp(.*)$ $1 break;
         proxy_pass http://seafile:8082;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        client_max_body_size 0;
-        proxy_connect_timeout  36000s;
-        proxy_read_timeout  36000s;
         proxy_request_buffering off;
+
+        client_max_body_size 0;
     }
 
 }

--- a/seafile.subdomain.conf.sample
+++ b/seafile.subdomain.conf.sample
@@ -1,0 +1,40 @@
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+# make sure that your seafile container is named seafile
+# make sure that your dns has a cname set for seafile
+
+    server_name seafile.*; # update to match the full domain e.g. seafile.example.com
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 10m;
+
+    location / {
+        include /config/nginx/resolver.conf;
+        proxy_pass http://seafile:8000;
+        proxy_read_timeout 310s;
+        proxy_set_header Host $host;
+        proxy_set_header Forwarded "for=$remote_addr;proto=$scheme";
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Connection "";
+        proxy_http_version 1.1;
+
+        client_max_body_size 0;
+    }
+
+    location /seafhttp {
+        include /config/nginx/resolver.conf;
+        rewrite ^/seafhttp(.*)$ $1 break;
+        proxy_pass http://seafile:8082;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        client_max_body_size 0;
+        proxy_connect_timeout  36000s;
+        proxy_read_timeout  36000s;
+        proxy_request_buffering off;
+    }
+
+}

--- a/seafile.subdomain.conf.sample
+++ b/seafile.subdomain.conf.sample
@@ -22,7 +22,6 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header Connection "";
-        proxy_http_version 1.1;
 
         client_max_body_size 0;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
Seafile is an open source file sync and share platform, focusing on reliability and performance. Seafile's built-in collaborative document SeaDoc, make it easy for collaborative writing and publishing documents. This configuration is to allow Seafile to work with SWAG, specifically allowing for file transfers to work. 


## Benefits of this PR and context
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Credit for this goes to this issue [here](https://github.com/linuxserver/reverse-proxy-confs/issues/425). Without this configuration it's unclear on how to get Seafile to load when fronted by SWAG. In addition file transfers fail even when the GUI of the service loads. Issue can be observed [here](https://forums.unraid.net/topic/164061-seafile/?do=findComment&comment=1453235) in the Unraid Forum. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I am running Unraid 6.12.11 with SWAG in front of any application exposed outside of my home LAN. I use Cloudflare for my DNS to manage resolutions for my domain. I have one custom docker network used for all services leveraging SWAG and I am using a different port in my setup. 

I have tested loading the service from both my LAN and public networks. I have tested file transfers with 1mb, 10mb, 1000mb, and 2gb files to ensure the functionality continues to work. 

## Source / References
<!--- Please include any forum posts/github links relevant to the PR -->
I've already linked a few sources above, but again was able to figure this out leveraging the following resources:

- [GitHub](https://github.com/linuxserver/reverse-proxy-confs/issues/425)
- [Unraid Forum](https://forums.unraid.net/topic/164061-seafile/?do=findComment&comment=1453235)
- [Seafile Docs](https://manual.seafile.com/docker/deploy_seafile_with_docker/)
- [Unraid Plugin](https://forums.unraid.net/topic/120473-support-fantucie-apps/)