### PR TITLE
include auth config files on Nextcloud

### DIFF
--- a/nextcloud.subdomain.conf.sample
+++ b/nextcloud.subdomain.conf.sample
@@ -24,7 +24,29 @@ server {
 
     client_max_body_size 0;
 
+    # enable for ldap auth (requires ldap-location.conf in the location block)
+    #include /config/nginx/ldap-server.conf;
+
+    # enable for Authelia (requires authelia-location.conf in the location block)
+    #include /config/nginx/authelia-server.conf;
+
+    # enable for Authentik (requires authentik-location.conf in the location block)
+    #include /config/nginx/authentik-server.conf;
+
     location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable for ldap auth (requires ldap-server.conf in the server block)
+        #include /config/nginx/ldap-location.conf;
+
+        # enable for Authelia (requires authelia-server.conf in the server block)
+        #include /config/nginx/authelia-location.conf;
+
+        # enable for Authentik (requires authentik-server.conf in the server block)
+        #include /config/nginx/authentik-location.conf;
+
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
         set $upstream_app nextcloud;


### PR DESCRIPTION
# Added includes for authentication mechanism for nextcloud

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
<!--- Describe your changes in detail -->
I simply added the different includes for Authelia, Authentik, ldap and http as a comment in the Nextcloud reverse proxy config file as those lines are also in other config files. 


## Benefits of this PR and context
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
This PR allow redirecting any request done to a Nextcloud instance behind SWAG to the authentication mechanism (if it exist) whereas it has to be entered manually before. As it is only commented code, nothing should be impacted and uncommenting those lines can be done at the user's discretion.

I was using SWAG with the docker auto-proxy-mod (and all it requirements), used Authelia with a wildcard to protect all my services behind (Nextcloud + SearXNG) even though it means logging twice (Authelia + Nextcloud), I don't mind.  The docker auto-proxy-mod automatically grab the config samples when the software is detected and has a generic template for others (including the lines I added here). It then proceeds to uncomment lines of any copied config files for any auth mechanism in function of their associated container label. In the case of Nextcloud, there was nothing to uncomment, thus, protecting my SearXNG instance and exposing my Nextcloud instance.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I just `docker exec -it bash swag` into my swag container, went to the /etc/nginx/http.d/auto-proxy-nextcloud.conf to add the lines for Authelia and I reloaded only the nginx server within the container with `/usr/sbin/nginx -c /config/nginx/nginx.conf -s reload`. Works like a charm now, but I would like to not do that every time neither configure it manually, so maybe for consistency of all the other config files here and for the sake of automation it could be a great idea to include those comments.


## Source / References
<!--- Please include any forum posts/github links relevant to the PR -->
[Docker auto proxy bash file](https://github.com/linuxserver/docker-mods/blob/swag-auto-proxy/root/app/auto-proxy.sh) in case you need it.