### PR TITLE
restrict vaultwarden admin page to LAN

### DIFF
--- a/vaultwarden.subdomain.conf.sample
+++ b/vaultwarden.subdomain.conf.sample
@@ -62,6 +62,13 @@ server {
         # enable for Authentik (requires authentik-server.conf in the server block)
         #include /config/nginx/authentik-location.conf;
 
+        # if you enable admin page via ADMIN_TOKEN env variable
+        # consider restricting access to LAN only via uncommenting the following lines
+        #allow 10.0.0.0/8;
+        #allow 172.16.0.0/12;
+        #allow 192.168.0.0/16;
+        #deny all;
+
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
         set $upstream_app vaultwarden;

--- a/vaultwarden.subfolder.conf.sample
+++ b/vaultwarden.subfolder.conf.sample
@@ -49,6 +49,13 @@ location ~  ^(/vaultwarden)?/admin {
     # enable for Authentik (requires authentik-server.conf in the server block)
     #include /config/nginx/authentik-location.conf;
 
+    # if you enable admin page via ADMIN_TOKEN env variable
+    # consider restricting access to LAN only via uncommenting the following lines
+    #allow 10.0.0.0/8;
+    #allow 172.16.0.0/12;
+    #allow 192.168.0.0/16;
+    #deny all;
+
     include /config/nginx/proxy.conf;
     include /config/nginx/resolver.conf;
     set $upstream_app vaultwarden;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
vaultwarden admin page should be restricted to local only

## Source / References
https://github.com/dani-garcia/vaultwarden/discussions/2626