### PR TITLE
restrict access to jellyfin's /metrics endpoint in subdomain

### DIFF
--- a/jellyfin.subdomain.conf.sample
+++ b/jellyfin.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2024/07/16
+## Version 2024/08/22
 # make sure that your jellyfin container is named jellyfin
 # make sure that your dns has a cname set for jellyfin
 # if jellyfin is running in bridge mode and the container is named "jellyfin", the below config should work as is

--- a/jellyfin.subdomain.conf.sample
+++ b/jellyfin.subdomain.conf.sample
@@ -37,4 +37,22 @@ server {
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
     }
+
+    # Restrict access to /metrics
+    # https://jellyfin.org/docs/general/networking/monitoring/#prometheus-metrics
+    location /jellyfin/metrics {
+        allow 192.168.0.0/16;
+        allow 10.0.0.0/8;
+        allow 172.16.0.0/12
+        allow 127.0.0.0/8;
+
+        deny all;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app jellyfin;
+        set $upstream_port 8096;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+    }
 }

--- a/jellyfin.subdomain.conf.sample
+++ b/jellyfin.subdomain.conf.sample
@@ -40,7 +40,7 @@ server {
 
     # Restrict access to /metrics
     # https://jellyfin.org/docs/general/networking/monitoring/#prometheus-metrics
-    location /jellyfin/metrics {
+    location /metrics {
         allow 192.168.0.0/16;
         allow 10.0.0.0/8;
         allow 172.16.0.0/12;

--- a/jellyfin.subdomain.conf.sample
+++ b/jellyfin.subdomain.conf.sample
@@ -43,7 +43,7 @@ server {
     location /jellyfin/metrics {
         allow 192.168.0.0/16;
         allow 10.0.0.0/8;
-        allow 172.16.0.0/12
+        allow 172.16.0.0/12;
         allow 127.0.0.0/8;
 
         deny all;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
<!--- Describe your changes in detail -->
According to the [docs](https://jellyfin.org/docs/general/networking/monitoring/#prometheus-metrics), Jellyfin is able to expose an endpoint which provide metrics about the instance. A user would have to change a text file configuration to activate it but the endpoint it's not meant to be publicly exposed.

## Benefits of this PR and context
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Despite `/metrics` not being available by default, users could benefit from already having the configuration inserted and avoiding misconfiguration in Jellyfin opening a security risk.

This indeed comes with the cost of a longer conf file for the benefit of only those who expose this Prometheus metrics. Tried to look for similar PRs but didn't find anything similar so I decided to open but I understand if this is not welcome.

I did not changed the subfolder because I don't actually use it but if anyone is able to provide the configuration this could also be added.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran nginx with the inserted block and tried to access it.

## Source / References
<!--- Please include any forum posts/github links relevant to the PR -->
[Docs](https://jellyfin.org/docs/general/networking/monitoring/#prometheus-metrics)