### PR TITLE
recipes.subdomain.conf: remove comment containing dead URL

### DIFF
--- a/recipes.subdomain.conf.sample
+++ b/recipes.subdomain.conf.sample
@@ -3,9 +3,6 @@
 # make sure that your dns has a cname set for recipes
 # make sure to mount /media/ in your swag container to point to your Recipes Media directory
 
-# if using Authelia use this one:
-# Doc: https://vabene1111.github.io/recipes/install/docker/#using-proxy-authentication
-
 server {
     listen 443 ssl;
     listen [::]:443 ssl;


### PR DESCRIPTION
- note our .sample already contains the authelia info that's in-line with all other proxy confs; no need for additional instructions in the file header

-----

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

