### PR TITLE
Add RomM subdomain conf

### DIFF
--- a/romm.subdomain.conf.sample
+++ b/romm.subdomain.conf.sample
@@ -42,14 +42,5 @@ server {
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
-        # Hide version
-        server_tokens off;
-
-        # Security headers
-        add_header X-Frame-Options "SAMEORIGIN" always;
-        add_header X-Content-Type-Options "nosniff" always;
-        add_header X-XSS-Protection "1; mode=block" always;
-        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-        add_header Referrer-Policy "no-referrer-when-downgrade" always;
     }
 }

--- a/romm.subdomain.conf.sample
+++ b/romm.subdomain.conf.sample
@@ -1,0 +1,55 @@
+## Version 2024/10/26
+# make sure that your romM container is named romm
+# make sure that your dns has a cname set for romm
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name romm.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    # enable for ldap auth (requires ldap-location.conf in the location block)
+    #include /config/nginx/ldap-server.conf;
+
+    # enable for Authelia (requires authelia-location.conf in the location block)
+    #include /config/nginx/authelia-server.conf;
+
+    # enable for Authentik (requires authentik-location.conf in the location block)
+    #include /config/nginx/authentik-server.conf;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable for ldap auth (requires ldap-server.conf in the server block)
+        #include /config/nginx/ldap-location.conf;
+
+        # enable for Authelia (requires authelia-server.conf in the server block)
+        #include /config/nginx/authelia-location.conf;
+
+        # enable for Authentik (requires authentik-server.conf in the server block)
+        #include /config/nginx/authentik-location.conf;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app romm;
+        set $upstream_port 8080;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+        # Hide version
+        server_tokens off;
+
+        # Security headers
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-XSS-Protection "1; mode=block" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header Referrer-Policy "no-referrer-when-downgrade" always;
+    }
+}


### PR DESCRIPTION
Add new RomM subdomain conf.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
<!--- Describe your changes in detail -->
I created a new sample subdomain config file for [RomM](https://romm.app/), "Your beautiful, powerful, self-hosted rom manager." I copied the nginx + ssl example from their [wiki](https://github.com/rommapp/romm/wiki/Reverse-Proxy#nginx--tls-https) into the provided template.

## Benefits of this PR and context
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
This PR adds support for RomM game manager to swag

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I ran the RomM docker container (+ MariaDB) on my Ubuntu server together with swag using docker compose. Made sure the domain connected, was able to download ROMs, run the emulator etc. Didn't find any issues. 
Checked that there were no entries in error.log

## Source / References
<!--- Please include any forum posts/github links relevant to the PR -->