### PR TITLE
Update port in maintainerr.subdomain.conf.sample

### DIFF
--- a/maintainerr.subdomain.conf.sample
+++ b/maintainerr.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2024/07/16
+## Version 2024/10/27
 # make sure that your maintainerr container is named maintainerr
 # make sure that your dns has a cname set for maintainerr
 
@@ -38,7 +38,7 @@ server {
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
         set $upstream_app maintainerr;
-        set $upstream_port 80;
+        set $upstream_port 6246;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [ ] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
<!--- Describe your changes in detail -->

default port changed in v2.0.0 --> fixing the template


## Benefits of this PR and context
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

proxy conf works for maintainerr > v1

Reported in <https://discord.com/channels/354974912613449730/1300141222677188670>

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

not at all

## Source / References
<!--- Please include any forum posts/github links relevant to the PR -->

https://github.com/jorenn92/Maintainerr/releases/tag/v2.0.0