### PR TITLE
Create dnsdist.subdomain.conf.sample

### DIFF
--- a/dnsdist.subdomain.conf.sample
+++ b/dnsdist.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2024/11/02
+## Version 2024/11/26
 # make sure that your container is named dnsdist
 # make sure that your dns has a cname set for dnsdist
 
@@ -8,10 +8,6 @@ server {
 
     server_name dnsdist.*;
 
-    include /config/nginx/ssl.conf;
-
-    server_tokens off;
-
     location /dns-query {
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
@@ -20,12 +16,6 @@ server {
         set $upstream_proto grpc;
         grpc_pass grpcs://$upstream_app:$upstream_port;
 
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-Host $host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Forwarded-Protocol $scheme;
         proxy_set_header Range $http_range;
         proxy_set_header If-Range $http_if_range;
     }

--- a/dnsdist.subdomain.conf.sample
+++ b/dnsdist.subdomain.conf.sample
@@ -1,3 +1,4 @@
+## Version 2024/11/02
 # make sure that your container is named dnsdist
 # make sure that your dns has a cname set for dnsdist
 

--- a/dnsdist.subdomain.conf.sample
+++ b/dnsdist.subdomain.conf.sample
@@ -1,0 +1,31 @@
+# make sure that your container is named dnsdist
+# make sure that your dns has a cname set for dnsdist
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+
+    server_name dnsdist.*;
+
+    include /config/nginx/ssl.conf;
+
+    server_tokens off;
+
+    location /dns-query {
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app dnsdist;
+        set $upstream_port 443;
+        set $upstream_proto grpc;
+        grpc_pass grpcs://$upstream_app:$upstream_port;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Protocol $scheme;
+        proxy_set_header Range $http_range;
+        proxy_set_header If-Range $http_if_range;
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
Add's dnsdist subdomain nginx conf file to resolve DoH queries at following path: `/dns-query`

## Benefits of this PR and context
Adds powerdns support

## How Has This Been Tested?
- Tested the config with running powerdns dnsdist container.
- `dig @dnsdist.<mydomain> +https google.com` working

## Source / References
<!--- Please include any forum posts/github links relevant to the PR -->