### PR TITLE
Update immich.subdomain.conf.sample

### DIFF
--- a/immich.subdomain.conf.sample
+++ b/immich.subdomain.conf.sample
@@ -1,7 +1,7 @@
 ## Version 2024/10/15
 # make sure that your immich container is named immich
 # make sure that your dns has a cname set for immich
-# immich v1.118+ only. For earlier versions, change $upstream_port to 3001 
+# immich v1.118+ only. For earlier versions, change $upstream_port to 3001
 
 server {
     listen 443 ssl;
@@ -38,7 +38,7 @@ server {
 
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app immich;
+        set $upstream_app immich-server;
         set $upstream_port 2283;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
@@ -48,7 +48,7 @@ server {
     location ~ (/immich)?/api {
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app immich;
+        set $upstream_app immich-server;
         set $upstream_port 2283;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;

--- a/immich.subdomain.conf.sample
+++ b/immich.subdomain.conf.sample
@@ -1,7 +1,7 @@
 ## Version 2024/10/15
-# make sure that your immich container is named immich
-# make sure that your dns has a cname set for immich
-# immich v1.118+ only. For earlier versions, change $upstream_port to 3001
+# make sure that your immich container is named immich-server
+# make sure that your dns has a cname set for immich-server
+# immich v1.118+ only with the official docker-compose.yml. For earlier versions, change $upstream_port to 3001
 
 server {
     listen 443 ssl;


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description
Renaming the default container name from immich to immich-server as that's what it called in the official compose file:
https://github.com/immich-app/immich/blob/v1.119.1/docker/docker-compose.yml#L12

## Benefits of this PR and context
It will work out of the box with the default configs, no need to edit the config or rename the container.

## How Has This Been Tested?
Using the default immich-compose.yaml.
With the old config it fails and nginx error.log says:
```
2024/11/02 19:58:48 [error] 1776#1776: *17 immich could not be resolved (3: Host not found), client: xxx.xxx.xxx.xxx, server: immich.*, request: "GET / HTTP/2.0", host: "immich.xxxx.xxx"
```
After changing it to immich-server it will start working, access.log saying:
```
84.1.208.124 - - [02/Nov/2024:20:19:03 +0100] "GET /auth/login HTTP/2.0" 200 6298 "-" "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:132.0) Gecko/20100101 Firefox/132.0"
84.1.208.124 - - [02/Nov/2024:20:19:03 +0100] "GET /_app/immutable/chunks/preload-helper.C1FmrZbK.js HTTP/2.0" 200 568 "https://immich.xxxx.xxx/auth/login" "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:132.0) Gecko/20100101 Firefox/132.0"
...
```

## Source / References
Not sure when was any of their container called simply immich by default, maybe never.
Looking back the changelog all I can find is removing immich-proxy in v1.88.0
https://github.com/immich-app/immich/releases/tag/v1.88.0