### PR TITLE
Allow access to Baby Buddy API without auth

### DIFF
--- a/babybuddy.subdomain.conf.sample
+++ b/babybuddy.subdomain.conf.sample
@@ -43,4 +43,14 @@ server {
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
     }
+
+    location ~ ^/api/ {
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app babybuddy;
+        set $upstream_port 8000;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    }
 }

--- a/babybuddy.subdomain.conf.sample
+++ b/babybuddy.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2024/07/16
+## Version 2024/12/29
 # make sure that your babybuddy container is named babybuddy
 # make sure that your dns has a cname set for babybuddy
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
This PR simply adds the [documented API endpoint](https://docs.baby-buddy.net/api/) to the config to be exempt from auth.

## Benefits of this PR and context
It allows the use of the Baby Buddy API while the rest of the app is otherwise secured.

## How Has This Been Tested?
I've been running this config with Authelia for authentication while using the API with my newborn 🎉 for the last couple weeks.

## Source / References
[Baby Buddy API docs](https://docs.baby-buddy.net/api/)