### PR TITLE
Create a new immich-server config sample.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -20,6 +20,6 @@
 * If the application needs further configuration, specify this in a comment
 
 * In most cases we want the comments for Authelia, ldap and basic auth to be present
-* If the application has known API endpoints, we prefer these to be exempt from auth trough a location block (provided the application has security on the endpoint)
+* If the application has known API endpoints, we prefer these to be exempt from auth through a location block (provided the application has security on the endpoint)
 
 * Files must not be executeable

--- a/immich-server.subdomain.conf.sample
+++ b/immich-server.subdomain.conf.sample
@@ -1,8 +1,8 @@
 ## Version 2024/12/06
-# make sure that your immich container is named immich
-# make sure that your dns has a cname set for immich
-# immich v1.118+ only using the old docker-compose.yml.
-# For earlier versions, change $upstream_port to 3001
+# make sure that your immich container is named immich-server
+# make sure that your dns has a cname set for immich-server
+# immich v1.118+ only with the official docker-compose.yml.
+# For earlier versions use immich.subdomain.conf.sample
 
 server {
     listen 443 ssl;
@@ -39,7 +39,7 @@ server {
 
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app immich;
+        set $upstream_app immich-server;
         set $upstream_port 2283;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
@@ -49,7 +49,7 @@ server {
     location ~ (/immich)?/api {
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app immich;
+        set $upstream_app immich-server;
         set $upstream_port 2283;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;

--- a/immich-server.subdomain.conf.sample
+++ b/immich-server.subdomain.conf.sample
@@ -39,7 +39,7 @@ server {
 
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app immich-server;
+        set $upstream_app immich_server;
         set $upstream_port 2283;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
@@ -49,7 +49,7 @@ server {
     location ~ (/immich)?/api {
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app immich-server;
+        set $upstream_app immich_server;
         set $upstream_port 2283;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;

--- a/immich.subdomain.conf.sample
+++ b/immich.subdomain.conf.sample
@@ -1,7 +1,7 @@
 ## Version 2024/12/06
 # make sure that your immich container is named immich
 # make sure that your dns has a cname set for immich
-# immich v1.118+ only using the old docker-compose.yml.
+# immich v1.118+ only using the old docker-compose.yml, for the updated docker-compose, use immich-server.subdomain.conf.sample.
 # For earlier versions, change $upstream_port to 3001
 
 server {


### PR DESCRIPTION



[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description

Immich's official docker-compose.yml uses the main immich service as `immich_server`, as per discussion in https://github.com/linuxserver/reverse-proxy-confs/pull/713 the feedback was to create a new config instead of updating the original.

That PR also used `immich-server`, so I'm not sure in @NLZ has a different docker setup to mine that changes the `container_name` directive to use `-` instead of `_`, but mine definitely creates `immich_server`:

```
❯ docker ps --format "{{.Names}}" | grep immich
immich_server
immich_postgres
immich_machine_learning
immich_redis
```

I updated the date on the original config to draw attention to this.

Also, I found a small typo in the CONTRIBUTING.md

## Benefits of this PR and context

This requires less setup for users with immich, which means less chance of mistakes.

## How Has This Been Tested?

I'm running this config locally in my SWAG instance without issues.

## Source / References

The original official docker-compose never had `immich` as the service name, I suspect that the original SWAG config came from a community based template: https://github.com/immich-app/immich/blame/7cc7fc0a0c974e907702e0887b48312d3dd0a2b4/server/docker-compose.yml

I couldn't find any details in the wiki history either for the old name.