### PR TITLE
for subfolder too... i guess they exist

### DIFF
--- a/calibre-web.subdomain.conf.sample
+++ b/calibre-web.subdomain.conf.sample
@@ -64,13 +64,15 @@ server {
 
     # Feed for Kobo
     location /kobo/ {
-        include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
         set $upstream_app calibre-web;
         set $upstream_port 8083;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+        proxy_set_header X-Forwarded-Host $http_host;
         proxy_set_header X-Scheme $scheme;
-        proxy_buffer_size 32k;
+        proxy_buffer_size 128k;
+        proxy_buffers 4 256k;
+        proxy_busy_buffers_size 256k;
     }
 }

--- a/calibre-web.subfolder.conf.sample
+++ b/calibre-web.subfolder.conf.sample
@@ -51,7 +51,6 @@ location ^~ /calibre-web/opds/ {
 
 # Feed for Kobo
 location ^~ /calibre-web/kobo/ {
-    include /config/nginx/proxy.conf;
     include /config/nginx/resolver.conf;
     set $upstream_app calibre-web;
     set $upstream_port 8083;
@@ -59,5 +58,7 @@ location ^~ /calibre-web/kobo/ {
     proxy_pass $upstream_proto://$upstream_app:$upstream_port;
     proxy_set_header X-Scheme $scheme;
     proxy_set_header X-Script-Name /calibre-web;
-    proxy_buffer_size 32k;
+    proxy_buffer_size 128k;
+    proxy_buffers 4 256k;
+    proxy_busy_buffers_size 256k;
 }


### PR DESCRIPTION
large comics weren't able to sync to kobo with the settings due to the proxy_buffers setting in proxy.conf, remove the inclusion and provide the specific requirements in the location block itself, per upstream dev's docs