### PR TITLE
Create minio.subdomain.conf.sample

### DIFF
--- a/minio.subdomain.conf.sample
+++ b/minio.subdomain.conf.sample
@@ -1,0 +1,42 @@
+## Version 2024/01/09
+# make sure that your minio container is named minio
+# make sure that your dns has a cname set for minio
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name storage.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    location / {
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app minio;
+        set $upstream_port 9001;  # MinIO console port
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+        # Additional headers for MinIO
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # API endpoint
+    location /api/ {
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app minio;
+        set $upstream_port 9000;  # MinIO API port
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [X ] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
Included minio.subdomain.conf.sample

## Benefits of this PR and context
Includes proxy conf for MinIO service by default.

## How Has This Been Tested?
Included in my swag config and all is working fine.

## Source / References
none