### PR TITLE
Fix Jellyfin for LG webOS

### DIFF
--- a/jellyfin.subdomain.conf.sample
+++ b/jellyfin.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2024/08/22
+## Version 2025/01/09
 # make sure that your jellyfin container is named jellyfin
 # make sure that your dns has a cname set for jellyfin
 # if jellyfin is running in bridge mode and the container is named "jellyfin", the below config should work as is
@@ -22,6 +22,9 @@ server {
         set $upstream_app jellyfin;
         set $upstream_port 8096;
         set $upstream_proto http;
+        if ($http_user_agent ~ Web0S) {
+            add_header X-Frame-Options "" always;
+        }
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
         proxy_set_header Range $http_range;
@@ -34,6 +37,9 @@ server {
         set $upstream_app jellyfin;
         set $upstream_port 8096;
         set $upstream_proto http;
+        if ($http_user_agent ~ Web0S) {
+            add_header X-Frame-Options "" always;
+        }
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
     }

--- a/jellyfin.subdomain.conf.sample
+++ b/jellyfin.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2025/01/09
+## Version 2025/01/11
 # make sure that your jellyfin container is named jellyfin
 # make sure that your dns has a cname set for jellyfin
 # if jellyfin is running in bridge mode and the container is named "jellyfin", the below config should work as is
@@ -22,9 +22,7 @@ server {
         set $upstream_app jellyfin;
         set $upstream_port 8096;
         set $upstream_proto http;
-        if ($http_user_agent ~ Web0S) {
-            add_header X-Frame-Options "" always;
-        }
+        add_header Access-Control-Allow-Origin "luna://com.webos.service.config" always;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
         proxy_set_header Range $http_range;
@@ -37,9 +35,7 @@ server {
         set $upstream_app jellyfin;
         set $upstream_port 8096;
         set $upstream_proto http;
-        if ($http_user_agent ~ Web0S) {
-            add_header X-Frame-Options "" always;
-        }
+        add_header Access-Control-Allow-Origin "luna://com.webos.service.config" always;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
     }

--- a/jellyfin.subfolder.conf.sample
+++ b/jellyfin.subfolder.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/02/05
+## Version 2025/01/09
 # make sure that your jellyfin container is named jellyfin
 # if jellyfin is running in bridge mode and the container is named "jellyfin", the below config should work as is
 # if not, replace the line "set $upstream_app jellyfin;" with "set $upstream_app <containername>;"
@@ -15,6 +15,9 @@ location ^~ /jellyfin/ {
     set $upstream_app jellyfin;
     set $upstream_port 8096;
     set $upstream_proto http;
+    if ($http_user_agent ~ Web0S) {
+        add_header X-Frame-Options "" always;
+    }
     proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
     proxy_set_header Range $http_range;

--- a/jellyfin.subfolder.conf.sample
+++ b/jellyfin.subfolder.conf.sample
@@ -1,4 +1,4 @@
-## Version 2025/01/09
+## Version 2025/01/11
 # make sure that your jellyfin container is named jellyfin
 # if jellyfin is running in bridge mode and the container is named "jellyfin", the below config should work as is
 # if not, replace the line "set $upstream_app jellyfin;" with "set $upstream_app <containername>;"
@@ -15,9 +15,7 @@ location ^~ /jellyfin/ {
     set $upstream_app jellyfin;
     set $upstream_port 8096;
     set $upstream_proto http;
-    if ($http_user_agent ~ Web0S) {
-        add_header X-Frame-Options "" always;
-    }
+    add_header Access-Control-Allow-Origin "luna://com.webos.service.config" always;
     proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
     proxy_set_header Range $http_range;


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

closes #627

## Description
Before this patch, using the [`jellyfin-webos`](https://github.com/jellyfin/jellyfin-webos) client to connect to a Jellyfin server behind a nginx reverse proxy using the [jellyfin.subdomain.conf.sample](https://github.com/linuxserver/reverse-proxy-confs/blob/master/jellyfin.subdomain.conf.sample) resulted in `Error -27` [described here](https://github.com/jellyfin/jellyfin-webos/issues/60#issue-1040511289).
I removed `X-Frame-Options` header if the `http_user_agent` contains `Web0S`, and it fix the `Error -27`.

> [!CAUTION]
>  The name of the os is Web**O**S (with the letter `O`), but the user agent is  Web**0**S with the number 0 as [documented here](https://webostv.developer.lge.com/develop/specifications/web-api-and-web-engine#useragent-string).

## How Has This Been Tested?
[This post](https://github.com/jellyfin/jellyfin-webos/issues/52#issuecomment-1519003178) suggested testing the presence / absence of `SAMEORIGIN` using this command: 
`curl -I -X GET $jellyfin_url` to check if `X-Frame-Options` was set to `SAMEORIGIN`.
Using the unpatched conf,  `X-Frame-Options` is set to `SAMEORIGIN` (and error -27 appears)
Using my patched conf, `X-Frame-Options` is not present, and the `jellyfin-webos` client can connect to the server.

> [!CAUTION]
>  I only tested the [jellyfin.subdomain.conf](https://github.com/linuxserver/reverse-proxy-confs/blob/8625ed9dbd0ae9aab4d64ac571d1c4403533ab74/jellyfin.subdomain.conf.sample), not the [jellyfin.subfolder.conf](https://github.com/linuxserver/reverse-proxy-confs/blob/8625ed9dbd0ae9aab4d64ac571d1c4403533ab74/jellyfin.subfolder.conf.sample).

## Source / References
In the Jellyfin [doc for nginx](https://jellyfin.org/docs/general/networking/nginx/), there is a note:
> NOTE: X-Frame-Options may cause issues with the webOS app