### PR TITLE
Create pingvin-share.subdomain.conf.sample

### DIFF
--- a/pingvin-share.subdomain.conf.sample
+++ b/pingvin-share.subdomain.conf.sample
@@ -1,0 +1,56 @@
+## Version 2025/01/15
+# make sure that your pingvin-share container is named pingvin-share
+# make sure that your dns has a cname set for pingvin-share
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name pingvin-share.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    # enable for ldap auth (requires ldap-location.conf in the location block)
+    #include /config/nginx/ldap-server.conf;
+
+    # enable for Authelia (requires authelia-location.conf in the location block)
+    #include /config/nginx/authelia-server.conf;
+
+    # enable for Authentik (requires authentik-location.conf in the location block)
+    #include /config/nginx/authentik-server.conf;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable for ldap auth (requires ldap-server.conf in the server block)
+        #include /config/nginx/ldap-location.conf;
+
+        # enable for Authelia (requires authelia-server.conf in the server block)
+        #include /config/nginx/authelia-location.conf;
+
+        # enable for Authentik (requires authentik-server.conf in the server block)
+        #include /config/nginx/authentik-location.conf;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app pingvin-share;
+        set $upstream_port 3000;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    }
+
+    location ~ (/pingvin-share)?/api {
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app pingvin-share;
+        set $upstream_port 3000;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+    
+    }
+}


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
Adds reverse proxy configuration for [stonith404/pingvin-share](https://github.com/stonith404/pingvin-share) docker container.

## Benefits of this PR and context
Adds missing reverse proxy configuration for [stonith404/pingvin-share](https://github.com/stonith404/pingvin-share) docker container.

## How Has This Been Tested?
This configuration has been tested by me, after incorporating pingvin-share docker container into my homelab environment.
**Steps used to test the configuration:**

1. Create and start pingvin-share docker container;
2. Add this configuration file to proxy-confs swag directory and remove .sample suffix
3. Set pingvin-share CNAME in your DNS provider configuration panel (Cloudflare was used during testing)
4. Restart both swag and pingvin-share docker container
5. Access pingvin-share container by navigating to https://pingvin-share.your-domain.tld

## Source / References
[Project Github Page](https://github.com/stonith404/pingvin-share)
[Project Website: Configuration](https://stonith404.github.io/pingvin-share/setup/configuration)