### PR TITLE
update ports IAW upstream documentation, add note for older versions

### DIFF
--- a/frigate.subdomain.conf.sample
+++ b/frigate.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2024/07/16
+## Version 2025/01/16
 # make sure that your frigate container is named frigate
 # make sure that your dns has a cname set for frigate
 # if you are on a version older than 0.14.0 set upstream_port to 5000 and upstream_proto to http

--- a/frigate.subdomain.conf.sample
+++ b/frigate.subdomain.conf.sample
@@ -1,6 +1,7 @@
 ## Version 2024/07/16
 # make sure that your frigate container is named frigate
 # make sure that your dns has a cname set for frigate
+# if you are on a version older than 0.14.0 set upstream_port to 5000 and upstream_proto to http
 
 server {
     listen 443 ssl;
@@ -38,8 +39,8 @@ server {
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
         set $upstream_app frigate;
-        set $upstream_port 5000;
-        set $upstream_proto http;
+        set $upstream_port 8971;
+        set $upstream_proto https;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
     }


### PR DESCRIPTION
as of 0.14.0 frigate devs suggest reverse proxies leverage port 8971 for secure authentication. Notes are added in the header for versions older than this
authentication can be disabled in frigate with the below snippet. Disabling auth is required to use header authentication via authentik, authelia, etc
```yaml
auth:
  enabled: False
```

https://docs.frigate.video/frigate/installation/#ports
https://docs.frigate.video/configuration/authentication
https://docs.frigate.video/guides/reverse_proxy