### PR TITLE
fix immich hostname

### DIFF
--- a/immich.subdomain.conf.sample
+++ b/immich.subdomain.conf.sample
@@ -1,7 +1,7 @@
 ## Version 2024/10/15
 # make sure that your immich container is named immich
 # make sure that your dns has a cname set for immich
-# immich v1.118+ only. For earlier versions, change $upstream_port to 3001 
+# immich v1.118+ only. For earlier versions, change $upstream_port to 3001
 
 server {
     listen 443 ssl;
@@ -38,7 +38,7 @@ server {
 
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app immich;
+        set $upstream_app immich-server;
         set $upstream_port 2283;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
@@ -48,7 +48,7 @@ server {
     location ~ (/immich)?/api {
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app immich;
+        set $upstream_app immich-server;
         set $upstream_port 2283;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
hostname should match the default config of immich

## Benefits of this PR and context
it's better for beginners and updating the config file

## How Has This Been Tested?
works for me :-)

## Source / References
[(https://github.com/immich-app/immich/blob/d249b63c995e2bfead7b7c62501bdbc5b65380df/docker/docker-compose.yml#L12)](https://github.com/immich-app/immich/blob/d249b63c995e2bfead7b7c62501bdbc5b65380df/docker/docker-compose.yml#L12)