### PR TITLE
Create memos.subdomain.conf.sample

### DIFF
--- a/memos.subdomain.conf.sample
+++ b/memos.subdomain.conf.sample
@@ -1,0 +1,61 @@
+## Version 2024/02/13
+# make sure that your memos container is named memos
+# make sure that your dns has a cname set for memos
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name memos.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";        
+
+    # enable for ldap auth (requires ldap-location.conf in the location block)
+    #include /config/nginx/ldap-server.conf;
+
+    # enable for Authelia (requires authelia-location.conf in the location block)
+    #include /config/nginx/authelia-server.conf;
+
+    # enable for Authentik (requires authentik-location.conf in the location block)
+    #include /config/nginx/authentik-server.conf;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable for ldap auth (requires ldap-server.conf in the server block)
+        #include /config/nginx/ldap-location.conf;
+
+        # enable for Authelia (requires authelia-server.conf in the server block)
+        #include /config/nginx/authelia-location.conf;
+
+        # enable for Authentik (requires authentik-server.conf in the server block)
+        #include /config/nginx/authentik-location.conf;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app memos;
+        set $upstream_port 5230;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+                
+    }
+
+    location ~ ^(/api) {
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+
+        set $upstream_app memos;
+        set $upstream_port 5230;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+    }
+
+}


### PR DESCRIPTION
Reverse proxy config for neos/moe memos using a subdomain

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
Created a file for Neos/MoeMemos as a sud domain. I'm not sure if the formatting is correct, but it has been tested and is working.

## Benefits of this PR and context
This sample config was missing.

## How Has This Been Tested?
Tested using android and ios through swag on a remote network using both apps and web interface. server is on unraid.

## Source / References
<!--- Please include any forum posts/github links relevant to the PR -->