### PR TITLE
Create triliumnext.conf.sample

### DIFF
--- a/triliumnext.conf.sample
+++ b/triliumnext.conf.sample
@@ -1,0 +1,55 @@
+## Version 2024/02/13
+# make sure that your triliumnext container is named triliumnext
+# make sure that your dns has a cname set for triliumnext
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name triliumnext.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade"; 
+    proxy_read_timeout 90;   
+    # enable for ldap auth (requires ldap-location.conf in the location block)
+    #include /config/nginx/ldap-server.conf;
+
+    # enable for Authelia (requires authelia-location.conf in the location block)
+    #include /config/nginx/authelia-server.conf;
+
+    # enable for Authentik (requires authentik-location.conf in the location block)
+    #include /config/nginx/authentik-server.conf;    
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable for ldap auth (requires ldap-server.conf in the server block)
+        #include /config/nginx/ldap-location.conf;
+
+        # enable for Authelia (requires authelia-server.conf in the server block)
+        #include /config/nginx/authelia-location.conf;
+
+        # enable for Authentik (requires authentik-server.conf in the server block)
+        #include /config/nginx/authentik-location.conf;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        
+        set $upstream_app triliumnext;
+        set $upstream_port 8080;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    }
+
+}


### PR DESCRIPTION
Created trililimnext sample rp file for swag

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
Created a file for triliumnext as a subdomain. I'm not sure if the formatting is correct, but it has been tested and is working.

## Benefits of this PR and context
This sample config was missing.

## How Has This Been Tested?
Tested using android ios and windows through swag on a remote network using web interface. server is on unraid.
This enables websockets so that changes in trilium are displayed without having to refresh the page.

## Source / References
<!--- Please include any forum posts/github links relevant to the PR -->