### PR TITLE
Add sample for Bar Assistant

### DIFF
--- a/barassistant.subdomain.conf.sample
+++ b/barassistant.subdomain.conf.sample
@@ -1,0 +1,82 @@
+## Version 2025/02/19
+# make sure that your meilisearch container is named meilisearch
+# make sure that your barassistant container is named barassistant
+# make sure that your salt-rim container is named salt-rim
+# make sure that your dns has a cname set for barassistant
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name barassistant.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 100M;
+
+    # enable for ldap auth (requires ldap-location.conf in the location block)
+    #include /config/nginx/ldap-server.conf;
+
+    # enable for Authelia (requires authelia-location.conf in the location block)
+    #include /config/nginx/authelia-server.conf;
+
+    # enable for Authentik (requires authentik-location.conf in the location block)
+    #include /config/nginx/authentik-server.conf;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable for ldap auth (requires ldap-server.conf in the server block)
+        #include /config/nginx/ldap-location.conf;
+
+        # enable for Authelia (requires authelia-server.conf in the server block)
+        #include /config/nginx/authelia-location.conf;
+
+        # enable for Authentik (requires authentik-server.conf in the server block)
+        #include /config/nginx/authentik-location.conf;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+		proxy_pass http://salt-rim:8080/;
+
+    }
+
+    location /bar/ {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable for ldap auth (requires ldap-server.conf in the server block)
+        #include /config/nginx/ldap-location.conf;
+
+        # enable for Authelia (requires authelia-server.conf in the server block)
+        #include /config/nginx/authelia-location.conf;
+
+        # enable for Authentik (requires authentik-server.conf in the server block)
+        #include /config/nginx/authentik-location.conf;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        proxy_pass http://barassistant:8080/;
+    }
+    location /search/ {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable for ldap auth (requires ldap-server.conf in the server block)
+        #include /config/nginx/ldap-location.conf;
+
+        # enable for Authelia (requires authelia-server.conf in the server block)
+        #include /config/nginx/authelia-location.conf;
+
+        # enable for Authentik (requires authentik-server.conf in the server block)
+        #include /config/nginx/authentik-location.conf;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        proxy_pass http://meilisearch:7700/;
+    }
+}

--- a/barassistant.subdomain.conf.sample
+++ b/barassistant.subdomain.conf.sample
@@ -12,7 +12,7 @@ server {
 
     include /config/nginx/ssl.conf;
 
-    client_max_body_size 100M;
+    client_max_body_size 0;
 
     # enable for ldap auth (requires ldap-location.conf in the location block)
     #include /config/nginx/ldap-server.conf;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
<!--- Describe your changes in detail -->
Add sample proxy config for [Bar Assistant](https://barassistant.app)

Note: For some reason, this config did not work when using the typical `set` directives as other configs use. Only passing the proxy address directly worked appropriately.

## Benefits of this PR and context
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
With three services running as seperate subfolder locations under the same subdomain, this app suggests deploy its own simple nginx to proxy. This config allows a user to put the services behind their existing SWAG service. `saltrim.subdomain.conf.sample` already exists, but simply points to the simple nginx proxy that the developer documents resulting in a double proxy situation. This submission consolidates the double proxy implementation into a single SWAG config that handles the individual paths.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on a new setup and another user tested as well in existing environment

## Source / References
<!--- Please include any forum posts/github links relevant to the PR -->