### PR TITLE
Add mailcow subdomain sample config

### DIFF
--- a/mailcow.subdomain.conf.sample
+++ b/mailcow.subdomain.conf.sample
@@ -9,7 +9,8 @@ server {
     listen 443 ssl;
     listen [::]:443 ssl;
 
-    server_name mailcow.* autoconfig.* autodiscover.*; # modify these names to match your domain/mailcow configuration
+    # modify these to match your domain/mailcow configuration
+    server_name mailcow.* autoconfig.* autodiscover.*;
 
     include /config/nginx/ssl.conf;
 

--- a/mailcow.subdomain.conf.sample
+++ b/mailcow.subdomain.conf.sample
@@ -1,0 +1,74 @@
+## Version 2025/03/16
+# make sure that your mailcow container is named mailcow
+# make sure that you are aqquainted with the mailcow documentation (https://docs.mailcow.email/)
+# make sure you have read the most important entries in the "Get Started" section, "Post Installation Tasks -> Reverse Proxy -> Overview" and "Post Installation Tasks -> Reverse Proxy -> Nginx" sections
+# make sure that your dns is configured as per your domain requirements and the mailcow documentation
+# make sure to set up a mechanism to copy your SSL certificate after each renewal to /data/assets/ssl/ directory for mailcow to use (see mailcow documentation in "Post Installation Tasks -> Reverse Proxy -> Overview")
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name mailcow.* autoconfig.* autodiscover.*; # modify these names to match your domain/mailcow configuration
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    # enable for ldap auth (requires ldap-location.conf in the location block)
+    #include /config/nginx/ldap-server.conf;
+
+    # enable for Authelia (requires authelia-location.conf in the location block)
+    #include /config/nginx/authelia-server.conf;
+
+    # enable for Authentik (requires authentik-location.conf in the location block)
+    #include /config/nginx/authentik-server.conf;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable for ldap auth (requires ldap-server.conf in the server block)
+        #include /config/nginx/ldap-location.conf;
+
+        # enable for Authelia (requires authelia-server.conf in the server block)
+        #include /config/nginx/authelia-location.conf;
+
+        # enable for Authentik (requires authentik-server.conf in the server block)
+        #include /config/nginx/authentik-location.conf;
+
+        include /config/nginx/resolver.conf;
+        set $upstream_app mailcow;
+        set $upstream_port 8080;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffer_size 128k;
+        proxy_buffers 64 512k;
+        proxy_busy_buffers_size 512k;
+    }
+
+    location /Microsoft-Server-ActiveSync {
+        include /config/nginx/resolver.conf;
+        set $upstream_app mailcow;
+        set $upstream_port 8080;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 75;
+        proxy_send_timeout 3650;
+        proxy_read_timeout 3650;
+        proxy_buffers 64 512k;
+
+        client_body_buffer_size 512k;
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
<!--- Describe your changes in detail -->
I made a sample reverse proxy config for [mailcow](https://mailcow.email). It is made according to the [documentation](https://docs.mailcow.email) and modified with some head-bashing :)
## Benefits of this PR and context
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Users, which host their mailcow mail server behind a SWAG reverse proxy will be able to easily set it up.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The config was tested for a mailcow server I am hosting for myself. It took some time to unbreak the SOGo mail client Exchange ActiveSync functionality after I mistakenly appended the URI for it to the end of the `proxy_pass` directive in the corresponding location block.
## Source / References
<!--- Please include any forum posts/github links relevant to the PR -->