### PR TITLE
Plex - Add proxy configuration for library streams

### DIFF
--- a/plex.subdomain.conf.sample
+++ b/plex.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2024/07/16
+## Version 2025/05/23
 # make sure that your plex container is named plex
 # make sure that your dns has a cname set for plex
 # if plex is running in bridge mode and the container is named "plex", the below config should work as is

--- a/plex.subdomain.conf.sample
+++ b/plex.subdomain.conf.sample
@@ -61,4 +61,12 @@ server {
         proxy_set_header X-Plex-Device-Vendor $http_x_plex_device_vendor;
         proxy_set_header X-Plex-Model $http_x_plex_model;
     }
+
+    location /library/streams/ {
+        set $upstream_app plex;
+        set $upstream_port 32400;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+        proxy_pass_request_headers off;
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
Hi, I'm experiencing a problem in Plex with Auto Proxy mod behind Swag, in some version of the plex app and via web, the subtitles are not displayed even if correctly active on the player; specifically the subtitles are external in SRT format.
I've found a post on the Plex forum describing the solution (link on Source/References), and I've tested it successfully including the fix in the Plex proxy configuration sample.
For reference before the fix in the error.log on nginx inside SWAG you can find error like this:
```
2025/03/20 14:43:57 [error] 1348#1348: *75271 upstream sent duplicate header line: 
"Content-Length: 57218", previous value: "Content-Length: 57218" while reading response header from upstream, 
client: x.x.x.x, server: plex.*, request: "GET /library/streams/1407?X-Plex-Token=xxxxxxxxxxxxxxxxxx&encoding=utf-8 
HTTP/1.1", upstream: "http://x.x.x.x:32400/library/streams/1407?X-Plex-Token=xxxxxxxxxxxxxxx&encoding=utf-8", host: 
"plex.domain.io"
```

## Benefits of this PR and context
In Plex you can finally use and see external SRT subtitles on Plex App versions like Linux or Web

## How Has This Been Tested?
Used SWAG with Auto-Proxy mod and modified the plex.subdomain.conf.sample with the new location `/library/streams/`; Played some movies with external SRT subtitles in Plex for Linux and via web, the subtitles now are working correctly, no more errors on nginx

## Source / References
https://forums.plex.tv/t/external-srt-subtitles-are-not-working/886540/29