### PR TITLE
Resolve api incompatibility with authelia for gitea

### DIFF
--- a/gitea.subdomain.conf.sample
+++ b/gitea.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2024/07/16
+## Version 2025/04/26
 # make sure that your gitea container is named gitea
 # make sure that your dns has a cname set for gitea
 # edit the following parameters in /data/gitea/conf/app.ini
@@ -49,7 +49,7 @@ server {
 
     }
 
-    location ~ (/gitea)?/info/lfs {
+    location ~ (/gitea)?/(api|info/lfs) {
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
         set $upstream_app gitea;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
<!--- Describe your changes in detail -->
Enable using gitea's api when using authelia.

## Benefits of this PR and context
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Fixes an issue when using the service.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on my personal setup

## Source / References
<!--- Please include any forum posts/github links relevant to the PR -->