### PR TITLE
Update Pi-hole subfolder config to support Pi-hole v6

### DIFF
--- a/pihole.subdomain.conf.sample
+++ b/pihole.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2024/07/16
+## Version 2025/04/29
 # make sure that your pihole container is named pihole
 # make sure that your dns has a cname set for pihole
 
@@ -45,20 +45,7 @@ server {
         proxy_hide_header X-Frame-Options;
     }
 
-    location /admin {
-        # enable the next two lines for http auth
-        #auth_basic "Restricted";
-        #auth_basic_user_file /config/nginx/.htpasswd;
-
-        # enable for ldap auth (requires ldap-server.conf in the server block)
-        #include /config/nginx/ldap-location.conf;
-
-        # enable for Authelia (requires authelia-server.conf in the server block)
-        #include /config/nginx/authelia-location.conf;
-
-        # enable for Authentik (requires authentik-server.conf in the server block)
-        #include /config/nginx/authentik-location.conf;
-
+    location /api {
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
         set $upstream_app pihole;

--- a/pihole.subfolder.conf.sample
+++ b/pihole.subfolder.conf.sample
@@ -1,6 +1,9 @@
-## Version 2023/02/05
+## Version 2025/04/29
 # make sure that your pihole container is named pihole
-# pihole does not require a base url setting
+# make sure that pihole is set to work with the base url /pihole
+
+# in pihole settings, under Webserver and API, set "webserver.paths.prefix" to "/pihole",
+# or run `[docker container exec pihole] pihole-FTL --config webserver.paths.prefix /pihole`
 
 location /pihole {
     return 301 $scheme://$host/pihole/;
@@ -31,24 +34,11 @@ location ^~ /pihole/ {
     proxy_hide_header X-Frame-Options;
 }
 
-location /pihole/admin {
-    return 301 $scheme://$host/pihole/admin/;
+location /pihole/api {
+    return 301 $scheme://$host/pihole/api/;
 }
 
-location ^~ /pihole/admin/ {
-    # enable the next two lines for http auth
-    #auth_basic "Restricted";
-    #auth_basic_user_file /config/nginx/.htpasswd;
-
-    # enable for ldap auth (requires ldap-server.conf in the server block)
-    #include /config/nginx/ldap-location.conf;
-
-    # enable for Authelia (requires authelia-server.conf in the server block)
-    #include /config/nginx/authelia-location.conf;
-
-    # enable for Authentik (requires authentik-server.conf in the server block)
-    #include /config/nginx/authentik-location.conf;
-
+location ^~ /pihole/api/ {
     include /config/nginx/proxy.conf;
     include /config/nginx/resolver.conf;
     set $upstream_app pihole;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
Add support for Pi-hole V6 by removing /admin and adding /api.  
Pi-hole V6 does not honor X-Forwarded-For but allows for setting a base URL.

## Benefits of this PR and context
Allows Pi-hole V6 to be configured behind a reverse proxy using a subfolder.

## How Has This Been Tested?
Tested on a Raspberry Pi 5 running Pi-hole V6 and linuxserver SWAG behind Organizer authentication.

## Source / References
[https://github.com/pi-hole/FTL/issues/2298]()
[https://discourse.pi-hole.net/t/cant-get-v6-webinterface-behind-nginx-reverse-proxy-to-work/76231/16]()