### PR TITLE
Add redmine conf

### DIFF
--- a/redmine.subdomain.conf.sample
+++ b/redmine.subdomain.conf.sample
@@ -1,3 +1,5 @@
+## Version 2025/05/04
+
 server {
     listen 443 ssl;
     listen [::]:443 ssl;

--- a/redmine.subdomain.conf.sample
+++ b/redmine.subdomain.conf.sample
@@ -1,0 +1,29 @@
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name redmine.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    access_log /var/log/nginx/redmine-access.log;
+    error_log /var/log/nginx/redmine-error.log;
+
+    location / {
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+
+        set $upstream_app redmine;
+        set $upstream_port 3000;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        client_max_body_size 10m;
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io

[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [[contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md)](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description

Added an Nginx reverse proxy configuration for a Redmine container. The config enables basic reverse proxy functionality to access Redmine through a subdomain.

## Benefits of this PR and context

This addition simplifies access to Redmine instances deployed via Docker by providing an out-of-the-box reverse proxy configuration. It improves usability for users running Redmine behind Nginx and aligns with existing reverse proxy examples in the repo.

## How Has This Been Tested?

Tested locally with Docker using the official Redmine container and Nginx. Verified that requests to the configured subdomain correctly forward to the Redmine container and serve the web interface without issues.

## Source / References

- https://hub.docker.com/_/redmine  
- https://www.redmine.org/