### PR TITLE
Fix Jellyfin CORS

### DIFF
--- a/jellyfin.subdomain.conf.sample
+++ b/jellyfin.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2025/01/11
+## Version 2025/05/18
 # make sure that your jellyfin container is named jellyfin
 # make sure that your dns has a cname set for jellyfin
 # if jellyfin is running in bridge mode and the container is named "jellyfin", the below config should work as is
@@ -22,7 +22,9 @@ server {
         set $upstream_app jellyfin;
         set $upstream_port 8096;
         set $upstream_proto http;
-        add_header Access-Control-Allow-Origin "luna://com.webos.service.config" always;
+        if ($http_user_agent ~ Web0S) {
+            add_header Access-Control-Allow-Origin "luna://com.webos.service.config" always;
+        }
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
         proxy_set_header Range $http_range;
@@ -35,7 +37,9 @@ server {
         set $upstream_app jellyfin;
         set $upstream_port 8096;
         set $upstream_proto http;
-        add_header Access-Control-Allow-Origin "luna://com.webos.service.config" always;
+        if ($http_user_agent ~ Web0S) {
+            add_header Access-Control-Allow-Origin "luna://com.webos.service.config" always;
+        }
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
     }

--- a/jellyfin.subfolder.conf.sample
+++ b/jellyfin.subfolder.conf.sample
@@ -1,4 +1,4 @@
-## Version 2025/01/11
+## Version 2025/05/18
 # make sure that your jellyfin container is named jellyfin
 # if jellyfin is running in bridge mode and the container is named "jellyfin", the below config should work as is
 # if not, replace the line "set $upstream_app jellyfin;" with "set $upstream_app <containername>;"
@@ -15,7 +15,9 @@ location ^~ /jellyfin/ {
     set $upstream_app jellyfin;
     set $upstream_port 8096;
     set $upstream_proto http;
-    add_header Access-Control-Allow-Origin "luna://com.webos.service.config" always;
+    if ($http_user_agent ~ Web0S) {
+        add_header Access-Control-Allow-Origin "luna://com.webos.service.config" always;
+    }
     proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
     proxy_set_header Range $http_range;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
<!--- Describe your changes in detail -->
This MR change the CORS for jellyfin, modifying it only in case of WebOS.  
closes #754

## Benefits of this PR and context
I misunderstood a comment on a [previous MR](https://github.com/linuxserver/reverse-proxy-confs/pull/731) from @quietsy on this subject. It introduced bugs on Chromecast and in `add_header` from `ssl.conf` on jellyfin nginx templates configs.


## How Has This Been Tested?
Tested the subdomain configuration on
- [Jellyfin for Android TV](https://play.google.com/store/apps/details?id=org.jellyfin.androidtv)
- [Jellyfin for kodi - Add-on mode](https://github.com/jellyfin/jellyfin-kodi)
- [Jellyfin Media Player](https://github.com/jellyfin/jellyfin-media-player)

I don't own a Chromecast. @Zazcallabah could you test it on your own device?

## Source / References
- [[BUG] chromecast for jellyfin is broken by commit 6f715575](https://github.com/linuxserver/reverse-proxy-confs/issues/754)
- [[BUG] Jellyfin: add_header lines in ssl.conf not applying due to commit 6f715575](https://github.com/linuxserver/reverse-proxy-confs/issues/759)