### PR TITLE
Create qbit-manage.subdomain.conf

### DIFF
--- a/qbit-manage.subdomain.conf.sample
+++ b/qbit-manage.subdomain.conf.sample
@@ -20,7 +20,7 @@ server {
     #include /config/nginx/authelia-server.conf;
 
     # enable for Authentik (requires authentik-location.conf in the location block)
-    # include /config/nginx/authentik-server.conf;
+    #include /config/nginx/authentik-server.conf;
 
     location / {
         # enable the next two lines for http auth
@@ -34,7 +34,7 @@ server {
         #include /config/nginx/authelia-location.conf;
 
         # enable for Authentik (requires authentik-server.conf in the server block)
-        # include /config/nginx/authentik-location.conf;
+        #include /config/nginx/authentik-location.conf;
 
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;

--- a/qbit-manage.subdomain.conf.sample
+++ b/qbit-manage.subdomain.conf.sample
@@ -1,0 +1,47 @@
+## Version 2024/07/16
+# make sure that your qbit-manage container is named qbit-manage
+# make sure that your dns has a cname set for qbit-manage
+# qbit-manage v4.5.0+ only
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name qbit-manage.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    # enable for ldap auth (requires ldap-location.conf in the location block)
+    #include /config/nginx/ldap-server.conf;
+
+    # enable for Authelia (requires authelia-location.conf in the location block)
+    #include /config/nginx/authelia-server.conf;
+
+    # enable for Authentik (requires authentik-location.conf in the location block)
+    # include /config/nginx/authentik-server.conf;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable for ldap auth (requires ldap-server.conf in the server block)
+        #include /config/nginx/ldap-location.conf;
+
+        # enable for Authelia (requires authelia-server.conf in the server block)
+        #include /config/nginx/authelia-location.conf;
+
+        # enable for Authentik (requires authentik-server.conf in the server block)
+        # include /config/nginx/authentik-location.conf;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app qbit-manage;
+        set $upstream_port 8080;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+    }
+
+}

--- a/qbit-manage.subdomain.conf.sample
+++ b/qbit-manage.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2024/07/16
+## Version 2025/07/12
 # make sure that your qbit-manage container is named qbit-manage
 # make sure that your dns has a cname set for qbit-manage
 # qbit-manage v4.5.0+ only


### PR DESCRIPTION
Adds new subdomain conf for qbit-manage.

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
This adds a new configuration template for qbit-manage.

## Benefits of this PR and context
Qbit-manage recently released a webUI in it's newest release, this adds a reverse proxy config for it.

## How Has This Been Tested?
I've tested this in my own swag configuration with authentik without any issues.

## Source / References
[<!--- Please include any forum posts/github links relevant to the PR -->](https://github.com/StuffAnThings/qbit_manage/wiki/Web-UI)