### PR TITLE
fix: update qui port for v0.3.0 change

### DIFF
--- a/qui.subdomain.conf.sample
+++ b/qui.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2025/08/23
+## Version 2025/08/28
 # make sure that your qui container is named qui
 # make sure that your dns has a cname set for qui
 
@@ -46,7 +46,7 @@ server {
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
         set $upstream_app qui;
-        set $upstream_port 8080;
+        set $upstream_port 7476;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 

--- a/qui.subfolder.conf.sample
+++ b/qui.subfolder.conf.sample
@@ -1,4 +1,4 @@
-## Version 2025/08/23
+## Version 2025/08/28
 # make sure that your qui container is named qui
 # make sure that qui is set to work with the base url /qui/
 
@@ -24,7 +24,7 @@ location ^~ /qui/ {
     include /config/nginx/proxy.conf;
     include /config/nginx/resolver.conf;
     set $upstream_app qui;
-    set $upstream_port 8080;
+    set $upstream_port 7476;
     set $upstream_proto http;
     proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
<!--- Describe your changes in detail -->
Update upstream port for qui to reflect v0.3.0 breaking change (8080 -> 7476)

## Benefits of this PR and context
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Ensures auto conf generation is correct for v0.3.0 onward

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local SWAG test port update

## Source / References
<!--- Please include any forum posts/github links relevant to the PR -->
https://github.com/autobrr/qui/releases/tag/v0.3.0

> ⚠️ BREAKING CHANGE
>
> Docker Users: The default internal port has changed from 8080 to 7476. This affects Docker healthchecks and port mappings.
> 
> Update your docker-compose.yml from :8080 to :7476