### PR TITLE
fix: Update recipes default port from 8080 to 80

### DIFF
--- a/recipes.subdomain.conf.sample
+++ b/recipes.subdomain.conf.sample
@@ -1,7 +1,6 @@
 ## Version 2025/10/12
 # make sure that your recipes container is named recipes
 # make sure that your dns has a cname set for recipes
-# make sure to mount /media/ in your swag container to point to your Recipes Media directory
 
 server {
     listen 443 ssl;
@@ -26,11 +25,6 @@ server {
 
     # enable for Tinyauth (requires tinyauth-location.conf in the location block)
     #include /config/nginx/tinyauth-server.conf;
-
-    # serve media files
-    location /media/ {
-        alias /media/;
-    }
 
     location / {
         # enable the next two lines for http auth


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
<!--- Describe your changes in detail -->

Since v3.2.0, Tandoor Recipes now comes with a pre-configured internal NGINX server. This has the following effect for the proxy configuration:

- The port exposed by default was changed from `8080` to `80`. 
- Their internal NGINX server now handles the mediafiles by itself, which used to be a manual configuration step in the SWAG config.

This PR reflects these changes in the `recipes.subdomain.conf.sample` file. 

## Benefits of this PR and context
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

At the moment, using the latest version of Tandoor Recipes with the default template leads to a broken configuration.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested this on my local instance of SWAG.

## Source / References
<!--- Please include any forum posts/github links relevant to the PR -->

See https://github.com/TandoorRecipes/recipes/issues/3851:

> Tandoor 1 includes gunicorn, a python WSGI server that handles python code well but is not meant to serve mediafiles. Thus it has always been recommended to setup an nginx webserver (not just a reverse proxy) in front of Tandoor to handle mediafiles. The gunicorn server by default is exposed on port 8080

> Tandoor 2 now bundles nginx inside the container and exposes **port 80 where mediafiles are handles by nginx** and all the other requests are (mostly) passed to gunicorn.

> To update you must simply change your port or reverse proxy configuration to access port `80` instead of port `8080`.