### PR TITLE
Updating Wizarr Subdomain Config

### DIFF
--- a/wizarr.subdomain.conf.sample
+++ b/wizarr.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2025/07/18
+## Version 2025/10/28
 # make sure that your wizarr container is named wizarr
 # make sure that your dns has a cname set for wizarr
 
@@ -48,6 +48,94 @@ server {
         set $upstream_app wizarr;
         set $upstream_port 5690;
         set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+    }
+
+    location /join {
+        # enable the next line for Organizr ServerAuth
+        # auth_request off;
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_proto http;
+        set $upstream_app Wizarr;
+        set $upstream_port 5690;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+    }
+
+    location ~ /j/* {
+        # enable the next line for Organizr ServerAuth
+        # auth_request off;
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_proto http;
+        set $upstream_app Wizarr;
+        set $upstream_port 5690;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+    }
+
+    location ~ /setup* {
+        # enable the next line for Organizr ServerAuth
+        # auth_request off;
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_proto http;
+        set $upstream_app Wizarr;
+        set $upstream_port 5690;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+    }
+
+    location ~ /static* {
+        # enable the next line for Organizr ServerAuth
+        # auth_request off;
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_proto http;
+        set $upstream_app Wizarr;
+        set $upstream_port 5690;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+    }
+
+    location ~ /wizard* {
+        # enable the next line for Organizr ServerAuth
+        # auth_request off;
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_proto http;
+        set $upstream_app Wizarr;
+        set $upstream_port 5690;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+    }
+
+    location ~ /setup* {
+        # enable the next line for Organizr ServerAuth
+        # auth_request off;
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_proto http;
+        set $upstream_app Wizarr;
+        set $upstream_port 5690;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+    }
+
+    location ~ /image-proxy* {
+        # enable the next line for Organizr ServerAuth
+        # auth_request off;
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_proto http;
+        set $upstream_app Wizarr;
+        set $upstream_port 5690;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+    }
+
+    location ~ /cinema-posters* {
+        # enable the next line for Organizr ServerAuth
+        # auth_request off;
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_proto http;
+        set $upstream_app Wizarr;
+        set $upstream_port 5690;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
     }
 }


### PR DESCRIPTION
Adding specific auth exemption location blocks as expected based on [Wizarr Docs](https://docs.wizarr.dev/using-wizarr/single-sign-on-sso).

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description
Updating the Wizarr Subdomain configuration to include specific location blocks for the join, j, static, setup, wizard, image-proxy, and cinema-posters api paths required for use.

## Benefits of this PR and context
Wizarr is a popular application used to streamline inviting users to personal media servers. This PR updates the default sample to match the instructions as provided by the official documentation.

## How Has This Been Tested?
This set of changes have been tested on my personal devices. I can confirm nginx is able to start and the service functions as expected. There are no build or lint tests associated with this project. 

## Source / References
[Official Docs](https://docs.wizarr.dev/using-wizarr/single-sign-on-sso)