### PR TITLE
Add configuration for Rustdesk OSS HBBS (HBBR) with SSL support

### DIFF
--- a/hbbs.subdomain.conf.sample
+++ b/hbbs.subdomain.conf.sample
@@ -1,0 +1,63 @@
+## Version 2025/11/06
+# make sure that your hbbs container is named hbbs
+# make sure that your dns has a cname set for hbbs
+# /ws/relay location only works if you have hbbr container configured and named hbbr
+# full guide https://rustdesk.com/docs/en/self-host/rustdesk-server-pro/faq/#set-up-https-for-web-console-manually
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name hbbs.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable for ldap auth (requires ldap-server.conf in the server block)
+        #include /config/nginx/ldap-location.conf;
+
+        # enable for Authelia (requires authelia-server.conf in the server block)
+        #include /config/nginx/authelia-location.conf;
+
+        # enable for Authentik (requires authentik-server.conf in the server block)
+        #include /config/nginx/authentik-location.conf;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        proxy_set_header        X-Real-IP       $remote_addr;
+        proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        proxy_pass http://hbbs:21114;
+
+    }
+
+    location /ws/id {
+        proxy_pass http://hbbs:21118;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 120s;
+    }
+
+    location /ws/relay {
+        proxy_pass http://hbbr:21119;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 120s;
+    }
+}

--- a/hbbs.subdomain.conf.sample
+++ b/hbbs.subdomain.conf.sample
@@ -42,7 +42,6 @@ server {
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
-        proxy_http_version 1.1;
         proxy_read_timeout 120s;
     }
 
@@ -62,7 +61,6 @@ server {
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
-        proxy_http_version 1.1;
         proxy_read_timeout 120s;
     }
 }

--- a/hbbs.subdomain.conf.sample
+++ b/hbbs.subdomain.conf.sample
@@ -41,8 +41,6 @@ server {
         set $upstream_port 21118;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
-
-        proxy_read_timeout 120s;
     }
 
     location /ws/relay {
@@ -60,7 +58,5 @@ server {
         set $upstream_port 21119;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
-
-        proxy_read_timeout 120s;
     }
 }

--- a/hbbs.subdomain.conf.sample
+++ b/hbbs.subdomain.conf.sample
@@ -15,30 +15,21 @@ server {
     client_max_body_size 0;
 
     location / {
-        # enable the next two lines for http auth
-        #auth_basic "Restricted";
-        #auth_basic_user_file /config/nginx/.htpasswd;
-
-        # enable for ldap auth (requires ldap-server.conf in the server block)
-        #include /config/nginx/ldap-location.conf;
-
-        # enable for Authelia (requires authelia-server.conf in the server block)
-        #include /config/nginx/authelia-location.conf;
-
-        # enable for Authentik (requires authentik-server.conf in the server block)
-        #include /config/nginx/authentik-location.conf;
-
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
         proxy_set_header        X-Real-IP       $remote_addr;
         proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
 
-        proxy_pass http://hbbs:21114;
-
+        set $upstream_app hbbs;
+        set $upstream_port 21114;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
     }
 
     location /ws/id {
-        proxy_pass http://hbbs:21118;
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
@@ -47,10 +38,19 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_read_timeout 120s;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app hbbs;
+        set $upstream_port 21118;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
     }
 
     location /ws/relay {
-        proxy_pass http://hbbr:21119;
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
@@ -59,5 +59,10 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_read_timeout 120s;
+
+        set $upstream_app hbbr;
+        set $upstream_port 21119;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
     }
 }

--- a/hbbs.subdomain.conf.sample
+++ b/hbbs.subdomain.conf.sample
@@ -30,39 +30,39 @@ server {
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
 
-        proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_read_timeout 120s;
 
-        include /config/nginx/proxy.conf;
-        include /config/nginx/resolver.conf;
         set $upstream_app hbbs;
         set $upstream_port 21118;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+        proxy_http_version 1.1;
+        proxy_read_timeout 120s;
     }
 
     location /ws/relay {
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
 
-        proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_read_timeout 120s;
 
         set $upstream_app hbbr;
         set $upstream_port 21119;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+        proxy_http_version 1.1;
+        proxy_read_timeout 120s;
     }
 }


### PR DESCRIPTION
Hi, I'm using Rustdesk OSS on prem, and for using it, especially with web client, It's suggested to add a reverse proxy in front of the HBBS service.
I was already using Swag on the machine, so I created and tested a config file to use HBBS; the config contains also a location config for use websockets with HBBR, that is usually installed along with HBBS
Full guide [here](https://rustdesk.com/docs/en/self-host/rustdesk-server-pro/faq/#set-up-https-for-web-console-manually)


[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [ ] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
Added new config file for Rustdesk OSS service HBBS

## Benefits of this PR and context
Use Rustdesk OSS service behind SSL Reverse Proxy

## How Has This Been Tested?
HBBS and HBBR Rustdesk Services on docker behind Swag container and dns name `hbbs.domain`

## Source / References
https://rustdesk.com/docs/en/self-host/rustdesk-server-pro/faq/#set-up-https-for-web-console-manually)