### PR TITLE
New sample config for snippet-box

### DIFF
--- a/ghost.subdomain.conf.sample
+++ b/ghost.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2025/07/18
+## Version 2025/09/17
 # make sure that your ghost container is named ghost
 # make sure that your dns has a cname set for ghost
 
@@ -50,5 +50,25 @@ server {
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
+    }
+
+    location ~ /.ghost/activitypub/* {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Host $http_host;
+        add_header X-Content-Type-Options "nosniff";
+        proxy_ssl_server_name on;
+        proxy_pass https://ap.ghost.org;
+    }
+
+    location ~ /.well-known/(webfinger|nodeinfo) {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Host $http_host;
+        add_header X-Content-Type-Options "nosniff";
+        proxy_ssl_server_name on;
+        proxy_pass https://ap.ghost.org;
     }
 }

--- a/ghost.subdomain.conf.sample
+++ b/ghost.subdomain.conf.sample
@@ -1,6 +1,7 @@
 ## Version 2025/09/17
 # make sure that your ghost container is named ghost
 # make sure that your dns has a cname set for ghost
+# Note: The Ghost(Pro) hosted ActivityPub Service (https://ap.ghost.org) has usage limits. See https://docs.ghost.org/install/docker#hosted-activitypub-usage-limits
 
 server {
     listen 443 ssl;

--- a/ghost.subfolder.conf.sample
+++ b/ghost.subfolder.conf.sample
@@ -1,8 +1,9 @@
-## Version 2023/02/05
+## Version 2025/09/17
 # make sure that your ghost container is named ghost
 # make sure that ghost is set to work with the base url /ghost/
 # Make sure you are using a subfolder in your ghost config file. https://ghost.org/docs/concepts/config/#url
 # Note: /ghost/ is by default used for the admin page. See https://ghost.org/docs/concepts/config/#admin-url
+# Note: Subfolder configuration does not support ActivityPub. See https://docs.ghost.org/update-major-version#get-activitypub-ready
 
 location /blog {
     # enable the next two lines for http auth

--- a/snippet-box.subdomain.conf.sample
+++ b/snippet-box.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2025/07/18
+## Version 2025/12/01
 # make sure that your snippet-box container is named snippet-box
 # make sure that your dns has a cname set for snippet-box
 
@@ -8,7 +8,7 @@ server {
     listen [::]:443 ssl;
 #    listen [::]:443 quic;
 
-    server_name paste.*;
+    server_name snippetbox.*;
 
     include /config/nginx/ssl.conf;
 

--- a/snippet-box.subdomain.conf.sample
+++ b/snippet-box.subdomain.conf.sample
@@ -1,0 +1,55 @@
+## Version 2025/07/18
+# make sure that your snippet-box container is named snippet-box
+# make sure that your dns has a cname set for snippet-box
+
+server {
+    listen 443 ssl;
+#    listen 443 quic;
+    listen [::]:443 ssl;
+#    listen [::]:443 quic;
+
+    server_name paste.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    # enable for ldap auth (requires ldap-location.conf in the location block)
+    #include /config/nginx/ldap-server.conf;
+
+    # enable for Authelia (requires authelia-location.conf in the location block)
+    #include /config/nginx/authelia-server.conf;
+
+    # enable for Authentik (requires authentik-location.conf in the location block)
+    #include /config/nginx/authentik-server.conf;
+
+    # enable for Tinyauth (requires tinyauth-location.conf in the location block)
+    #include /config/nginx/tinyauth-server.conf;
+
+    location / {
+
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable for ldap auth (requires ldap-server.conf in the server block)
+        #include /config/nginx/ldap-location.conf;
+
+        # enable for Authelia (requires authelia-server.conf in the server block)
+        #include /config/nginx/authelia-location.conf;
+
+        # enable for Authentik (requires authentik-server.conf in the server block)
+        #include /config/nginx/authentik-location.conf;
+
+        # enable for Tinyauth (requires tinyauth-server.conf in the server block)
+        #include /config/nginx/tinyauth-location.conf;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app snippet-box;
+        set $upstream_port 5000;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    }
+}


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
Adds new sample config for snippet-box

## Benefits of this PR and context
Including sample proxy configs helps new users to get started with SWAG

## How Has This Been Tested?
Testing environment:
UnRAID's built-in Docker implementation with SWAG and snippet-box containers installed.

Testing Details:
- configured DNS with new CNAME for new subdomain
- configured SWAG to with new subdomain
- renewed SSL cert
- added the new proxy subdomain config for snippet-box
- can now access snippet-box on port 443 using the new subdomain, both locally and remotely.

## Source / References
https://github.com/pawelmalak/snippet-box