### PR TITLE
add conf for copyparty

### DIFF
--- a/copyparty.subdomain.conf.sample
+++ b/copyparty.subdomain.conf.sample
@@ -18,7 +18,7 @@ server {
     #include /config/nginx/ldap-server.conf;
 
     # enable for Authelia (requires authelia-location.conf in the location block)
-    include /config/nginx/authelia-server.conf;
+    #include /config/nginx/authelia-server.conf;
 
     # enable for Authentik (requires authentik-location.conf in the location block)
     #include /config/nginx/authentik-server.conf;
@@ -35,7 +35,7 @@ server {
         #include /config/nginx/ldap-location.conf;
 
         # enable for Authelia (requires authelia-server.conf in the server block)
-        include /config/nginx/authelia-location.conf;
+        #include /config/nginx/authelia-location.conf;
 
         # enable for Authentik (requires authentik-server.conf in the server block)
         #include /config/nginx/authentik-location.conf;


### PR DESCRIPTION
tested locally; did testing from internal lan using internal dns and external using external dns and cloudflare proxy. shows correct IP assuming copyparty itself is properly configured.

copyparty.conf relevant section below

```
# not actually YAML but lets pretend:
# -*- mode: yaml -*-
# vim: ft=yaml:

# append some arguments to the commandline;
# accepts anything listed in --help (leading dashes are optional)
# and inline comments are OK if there is 2 spaces before the '#'
[global]
  e2dsa  # enable file indexing and filesystem scanning
  #e2ts   # and enable multimedia indexing
  ansi

  rproxy: 1
  #xff-hdr: cf-connecting-ip
  xff-src: lan
  idp-logout: https://authelia.deez.nuts/logout?rd=https://cp.deez.nuts
  idp-h-usr: Remote-User
  idp-h-grp: Remote-Groups
```