### PR TITLE
fix: update slskd port and add subdomain config

### DIFF
--- a/slskd.subdomain.conf.sample
+++ b/slskd.subdomain.conf.sample
@@ -1,0 +1,47 @@
+## Version 2026/04/04
+# make sure that your slskd container is named slskd
+# make sure that your dns has a cname set for slskd
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name slskd.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    # enable for ldap auth (requires ldap-location.conf in the location block)
+    #include /config/nginx/ldap-server.conf;
+
+    # enable for Authelia (requires authelia-location.conf in the location block)
+    #include /config/nginx/authelia-server.conf;
+
+    # enable for Authentik (requires authentik-location.conf in the location block)
+    #include /config/nginx/authentik-server.conf;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable for ldap auth (requires ldap-server.conf in the server block)
+        #include /config/nginx/ldap-location.conf;
+
+        # enable for Authelia (requires authelia-server.conf in the server block)
+        #include /config/nginx/authelia-location.conf;
+
+        # enable for Authentik (requires authentik-server.conf in the server block)
+        #include /config/nginx/authentik-location.conf;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app slskd;
+        set $upstream_port 5030;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    }
+
+}

--- a/slskd.subfolder.conf.sample
+++ b/slskd.subfolder.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/02/05
+## Version 2026/04/04
 # make sure that your slskd container is named slskd
 # make sure that slskd is set to work with the base url /slskd/
 # first edit the slskd.yml and set 'url_base: /slskd' and restart the slskd container
@@ -20,7 +20,7 @@ location ^~ /slskd {
     include /config/nginx/proxy.conf;
     include /config/nginx/resolver.conf;
     set $upstream_app slskd;
-    set $upstream_port 5000;
+    set $upstream_port 5030;
     set $upstream_proto http;
     proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description

Fix the existing slskd subfolder config which is using the old port and add a new subdomain config for the same container.

## Benefits of this PR and context

- Fix issue #797 by updating the subfolder slskd reverse proxy config to use port 5030. slskd switched HTTP from port 5000 to 5030 in version [0.17.3](https://github.com/slskd/slskd/releases/tag/0.17.3).
- Add a sample subdomain reverse proxy config for the same container based on the example one for SWAG from the slskd documentation.

## How Has This Been Tested?

- Using the new subdomain config successfully.
- No testing of the subfolder config was done, but the change is self-explanatory.

## Source / References

- https://github.com/linuxserver/reverse-proxy-confs/issues/797
- https://github.com/slskd/slskd/blob/master/docs/reverse_proxy.md#swag
