### PR TITLE
gitea: support git credential manager oauth flow

### DIFF
--- a/gitea.subdomain.conf.sample
+++ b/gitea.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2025/07/18
+## Version 2026/07/03
 # make sure that your gitea container is named gitea
 # make sure that your dns has a cname set for gitea
 # edit the following parameters in /data/gitea/conf/app.ini

--- a/gitea.subdomain.conf.sample
+++ b/gitea.subdomain.conf.sample
@@ -57,6 +57,18 @@ server {
 
     }
 
+    # support for git credential manager. don't proxy a redirect to localhost in the oauth flow.
+    location /login/oauth/grant {
+        proxy_redirect ~^http://127.0.0.1(.*) http://127.0.0.1$1;
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app gitea;
+        set $upstream_port 3000;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    }
+
     location ~ (/gitea)?/(api|info/lfs) {
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [X ] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
git credential manager sets up an oauth flow which requires a redirect to a localhost port to complete the oauth flow. The proxt_redirect http:// scheme$:// directive in proxy.conf causes this to be rewritten to https://. Make an exception for redirects to localhost so that the oauth login will complete.

## Benefits of this PR and context
git operations using the git credential manager with gitea can successfully set up oauth tokens.

## How Has This Been Tested?
Test git clone / git fetch operations that initiate an oauth login using git for windows default installation which uses git credential manager.
