### PR TITLE
fix: add X-OPENHAB-AUTH-HEADER cookie to prevent login conflict with …

### DIFF
--- a/openhab.subdomain.conf.sample
+++ b/openhab.subdomain.conf.sample
@@ -30,6 +30,8 @@ server {
         # enable the next two lines for http auth
         #auth_basic "Restricted";
         #auth_basic_user_file /config/nginx/.htpasswd;
+        #add_header Set-Cookie X-OPENHAB-AUTH-HEADER=1;
+        #proxy_set_header Authorization "";
 
         # enable for ldap auth (requires ldap-server.conf in the server block)
         #include /config/nginx/ldap-location.conf;


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
------------------------------
 - [ ] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications
------------------------------
## Description
Add `X-OPENHAB-AUTH-HEADER` cookie to the openHAB nginx reverse proxy
configuration. When nginx basic auth is enabled, both nginx and openHAB 3+
compete for the HTTP `Authorization` header — nginx sets it to `Basic ...`
while openHAB sets it to `Bearer ...` after login. This causes openHAB
authentication to fail silently when accessed through the proxy.

The fix instructs the openHAB UI to use the alternative `X-OPENHAB-TOKEN`
header for its own token instead of `Authorization`, allowing both
authentication layers to coexist without conflict.

```nginx
add_header Set-Cookie "X-OPENHAB-AUTH-HEADER=true;path=/;Secure";
```

## Benefits of this PR and context
Without this fix, users who enable nginx basic auth on top of openHAB 3+
experience a broken login flow: the openHAB login page appears to accept
credentials but immediately fails, requiring the user to dismiss the nginx
auth popup and re-authenticate through openHAB's own login screen. This
is a known issue affecting all openHAB 3+ installations behind a nginx
reverse proxy with basic auth enabled.

This one-line addition makes the sample configuration work correctly
out of the box for openHAB 3+ without affecting openHAB 2.x compatibility.

## How Has This Been Tested?
Tested on a personal homelab running:
- LinuxServer SWAG container (nginx)
- openHAB 3+ running on a Raspberry Pi, proxied via the SWAG subdomain
  configuration
- nginx basic auth enabled via `.htpasswd`

Verified that after adding the cookie header:
- The nginx basic auth popup works correctly on first access
- The openHAB login page authenticates successfully without conflict
- Both authenticated sessions coexist without interfering with each other
- Removing the cookie and reloading reproduces the original broken behavior

## Source / References
- openHAB Community discussion (proposed by openHAB core developer Yannick
  Schaus): https://community.openhab.org/t/oh3-with-nginx-reverse-proxy-and-authentication/106528
- openHAB official security documentation: https://www.openhab.org/docs/installation/security.html