### PR TITLE
Enable CORS and API access in configuration

### DIFF
--- a/wallabag.subdomain.conf.sample
+++ b/wallabag.subdomain.conf.sample
@@ -53,4 +53,45 @@ server {
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
     }
+
+    # Allows API access, including with WallaBag OAuth. Useful for example w/WallaBagger browser extension.
+    #location ~ ^/(api/(entries|tags|annotations|info|version|user|graphql)(\.json)?(/.*)?|oauth/v2/(token|auth))$ {
+    #    include /config/nginx/proxy.conf;
+    #    include /config/nginx/resolver.conf;
+    #    set $upstream_app wallabag;
+    #    set $upstream_port 80;
+    #    set $upstream_proto http;
+    #
+    #    # + CORS ------------------------------------------------------------------------------------------------ +
+    #
+    #    # Least secure; uncomment only if needed (and comment out the other 2).
+    #    #add_header 'Access-Control-Allow-Origin' '*' always;
+    #
+    #    # Allows CORS only for browser extensions? (less secure than your specific extension ID, but more than '*')
+    #    # and more portable.
+    #    set $cors_origin "";
+    #    if ($http_origin ~* "^(chrome|moz)-extension://") {
+    #        set $cors_origin $http_origin;
+    #    }
+    #    add_header 'Access-Control-Allow-Origin' $cors_origin always;
+    #
+    #    # Most secure if only using WallaBagger/browser extension (but must match its specific extension ID)
+    #    #add_header 'Access-Control-Allow-Origin' 'chrome-extension://gbmgphmejlcoihgedabhgjdkcahacjlj' always;
+    #
+    #    # Least secure; uncomment only if needed.
+    #    #add_header 'Access-Control-Allow-Methods' 'GET, POST, PATCH, PUT, DELETE, OPTIONS' always;
+    #
+    #    # Most secure if only using WallaBagge/browser extension
+    #    add_header 'Access-Control-Allow-Methods' 'GET, POST, PATCH, OPTIONS' always;
+    #
+    #    add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type' always;
+    #
+    #    if ($request_method = OPTIONS) {
+    #        return 204;
+    #    }
+    #
+    #    # + CORS End--------------------------------------------------------------------------------------------- +
+    #
+    #    proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+    #}
 }


### PR DESCRIPTION
Uncomment CORS configuration for API access and WallaBagger extension.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
<!--- Describe your changes in detail -->

Added API/OAuth location block (commented out by default)

## Benefits of this PR and context
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

Browser extensions (i.e. WallaBagger) and other things requiring access need this.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Using live on my own machines. If using something like Authelia/Authentik/TinyAuth be sure to also bypass the API/OAuth paths for the WallaBag container;

i.e.

    tinyauth.apps.wallabag.path.allow: "^/(api|oauth)(/.*)?$$"