### PR TITLE
Pihole v6 requires the path to be configured. Updated instructions.

### DIFF
--- a/pihole.subfolder.conf.sample
+++ b/pihole.subfolder.conf.sample
@@ -1,6 +1,8 @@
-## Version 2023/02/05
+## Version 2026/06/26
 # make sure that your pihole container is named pihole
-# pihole does not require a base url setting
+# pihole before v6 does not require a base url setting
+# pihole v6+ needs to ensure the webserver.paths.prefix setting is set to /pihole 
+# this can be configured directly in the web ui or in the pihole.toml file
 
 location /pihole {
     return 301 $scheme://$host/pihole/;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/reverse-proxy-confs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description
<!--- Describe your changes in detail -->
The default subfolder conf still functions correctly after the v6 pihole update given the instance is set up correctly. The previous instructions comment says that a base url is not required. I have updated the instructions to specify that v6 pihole does require a prefix. 

## Benefits of this PR and context
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Having accurate instructions would reduce confusion for users trying to set up this conf.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
After following my updated instructions myself, I can successfully access my pihole instance through the subfolder. 

## Source / References
<!--- Please include any forum posts/github links relevant to the PR -->
N/A